### PR TITLE
chore: enable dependabot automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -26,8 +24,6 @@ updates:
       - "dependencies"
       - "npm"
       - "frontend"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            exit 0
+          fi
+          gh pr merge "$PR_URL" --auto --merge


### PR DESCRIPTION
Enable automatic merge for Dependabot PRs and remove human assignment from Dependabot updates.