### PR TITLE
feat: embed SumUp sponsor widget

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,237 +4,486 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="color-scheme" content="light dark" />
-<title>Apoie Meus Projetos · PIX</title>
-<meta name="description" content="Página de doação PIX para projetos open-source de Leonardo Cardozo Vargas." />
+<title>Apoie Calculadora App - LCV Ideas &amp; Software</title>
+<meta name="description" content="Página de apoio ao projeto Calculadora App com pagamento seguro pelo SumUp Card Widget." />
 <meta name="robots" content="noindex,follow" />
+<script src="https://gateway.sumup.com/gateway/ecom/card/v2/sdk.js" defer></script>
 <style>
   :root {
-    --bg: #ffffff;
-    --fg: #0f172a;
-    --muted: #475569;
-    --card: #f8fafc;
-    --border: #e2e8f0;
+    --bg: #f6f8fb;
+    --fg: #111827;
+    --muted: #526071;
+    --card: #ffffff;
+    --border: #d8e0ea;
     --accent: #2563eb;
-    --code-bg: #f1f5f9;
-    --code-fg: #0f172a;
-    --ok: #16a34a;
+    --accent-strong: #0f766e;
+    --danger: #b91c1c;
+    --ok: #0f766e;
+    --soft: #eef7f6;
+    --shadow: rgba(15, 23, 42, 0.08);
   }
   @media (prefers-color-scheme: dark) {
     :root {
       --bg: #0b1220;
-      --fg: #e2e8f0;
-      --muted: #94a3b8;
+      --fg: #e7edf5;
+      --muted: #9aa8ba;
       --card: #111827;
-      --border: #1f2937;
+      --border: #253246;
       --accent: #60a5fa;
-      --code-bg: #0f172a;
-      --code-fg: #e2e8f0;
-      --ok: #22c55e;
+      --accent-strong: #2dd4bf;
+      --danger: #fca5a5;
+      --ok: #5eead4;
+      --soft: #0f2428;
+      --shadow: rgba(0, 0, 0, 0.28);
     }
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
   body {
-    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    min-height: 100vh;
     background: var(--bg);
     color: var(--fg);
-    min-height: 100vh;
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 24px 16px;
+    padding: 28px 16px;
   }
-  main {
-    max-width: 560px;
-    width: 100%;
+  main { width: min(840px, 100%); }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 22px;
+  }
+  .mark {
+    width: 46px;
+    height: 46px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: white;
+    font-weight: 800;
+    letter-spacing: 0;
   }
   h1 {
-    font-size: 24px;
-    margin: 0 0 4px;
-    font-weight: 700;
-    letter-spacing: -0.01em;
+    font-size: clamp(24px, 4vw, 34px);
+    line-height: 1.12;
+    margin: 0;
+    font-weight: 760;
+    letter-spacing: 0;
   }
   .lede {
     color: var(--muted);
-    margin: 0 0 24px;
-    font-size: 14px;
+    margin: 8px 0 0;
+    font-size: 15px;
   }
-  .lede a { color: var(--accent); text-decoration: none; }
-  .lede a:hover { text-decoration: underline; }
-  .card {
+  .panel {
     background: var(--card);
     border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 20px;
-    margin-bottom: 16px;
+    border-radius: 14px;
+    padding: 24px;
+    box-shadow: 0 14px 32px var(--shadow);
   }
-  .qr-wrap {
-    background: #ffffff;
-    border-radius: 8px;
-    padding: 16px;
-    display: flex;
-    justify-content: center;
-    margin-bottom: 12px;
-  }
-  .qr-wrap svg {
-    width: 240px;
-    height: 240px;
-    display: block;
-    image-rendering: pixelated;
-  }
-  .qr-caption {
-    text-align: center;
-    color: var(--muted);
-    font-size: 13px;
-    margin: 0;
+  .layout {
+    display: grid;
+    grid-template-columns: minmax(0, 0.95fr) minmax(320px, 1.05fr);
+    gap: 22px;
+    align-items: start;
   }
   h2 {
-    font-size: 14px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    font-size: 18px;
+    margin: 0 0 8px;
+    font-weight: 740;
+    letter-spacing: 0;
+  }
+  p { margin: 0; }
+  .muted { color: var(--muted); }
+  form {
+    display: grid;
+    gap: 14px;
+    margin-top: 18px;
+  }
+  label {
+    display: grid;
+    gap: 6px;
     color: var(--muted);
-    margin: 0 0 8px;
-    font-weight: 600;
+    font-size: 14px;
+    font-weight: 650;
   }
-  code, .code-block {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  }
-  .code-block {
-    background: var(--code-bg);
-    color: var(--code-fg);
+  input {
+    min-height: 44px;
+    width: 100%;
     border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 12px;
-    font-size: 13px;
-    word-break: break-all;
-    overflow-wrap: anywhere;
-    margin: 0 0 8px;
+    border-radius: 10px;
+    background: var(--card);
+    color: var(--fg);
+    font: inherit;
+    padding: 0 12px;
+    outline: none;
   }
-  .copy-row {
-    display: flex;
+  input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+  }
+  .amounts {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
     gap: 8px;
-    align-items: stretch;
-    margin-bottom: 4px;
   }
-  .copy-row .code-block { flex: 1; margin: 0; }
   button {
+    min-height: 44px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--card);
+    color: var(--fg);
+    font: inherit;
+    font-weight: 720;
+    cursor: pointer;
+    transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease;
+  }
+  button:hover { transform: translateY(-1px); border-color: var(--accent); }
+  button:active { transform: translateY(1px) scale(0.99); }
+  .amount-btn[aria-pressed="true"] {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, var(--card));
+  }
+  .primary {
+    border: 0;
     background: var(--accent);
     color: white;
-    border: 0;
-    border-radius: 8px;
-    padding: 0 16px;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    white-space: nowrap;
-    font-family: inherit;
   }
-  button:hover { filter: brightness(1.05); }
-  button:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
+  .primary:disabled {
+    cursor: wait;
+    opacity: 0.72;
+    transform: none;
   }
-  button.copied { background: var(--ok); }
-  ol {
-    margin: 0;
-    padding-left: 20px;
+  .note, .status {
+    margin-top: 16px;
+    padding: 13px 14px;
+    border-radius: 10px;
+    background: var(--soft);
     color: var(--muted);
+    border: 1px solid var(--border);
     font-size: 14px;
   }
-  ol li { margin-bottom: 4px; }
-  ol li strong { color: var(--fg); font-weight: 600; }
+  .status[hidden], .widget-shell[hidden] { display: none; }
+  .status.error { color: var(--danger); }
+  .status.success { color: var(--ok); }
+  .widget-shell {
+    min-height: 320px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px;
+    background: var(--card);
+  }
+  #sumup-card { min-height: 260px; }
+  .repo-link {
+    display: inline-flex;
+    margin-top: 16px;
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 700;
+  }
   footer {
-    text-align: center;
     color: var(--muted);
     font-size: 13px;
-    margin-top: 24px;
+    margin-top: 18px;
+    text-align: center;
   }
-  footer a { color: var(--accent); text-decoration: none; }
-  footer a:hover { text-decoration: underline; }
+  @media (max-width: 760px) {
+    .layout { grid-template-columns: 1fr; }
+    .panel { padding: 20px; }
+    .amounts { grid-template-columns: repeat(2, 1fr); }
+  }
 </style>
 </head>
 <body>
 <main>
-  <h1>Apoie <code>Meus Projetos</code></h1>
-  <p class="lede">Doação via PIX para projetos open-source de <a href="https://github.com/lcv-leo">Leonardo Cardozo Vargas</a>. Lista completa em <a href="https://github.com/lcv-leo?tab=repositories">github.com/lcv-leo</a>.</p>
-
-  <section class="card" aria-labelledby="qr-h">
-    <h2 id="qr-h">QR Code</h2>
-    <div class="qr-wrap" aria-hidden="false">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 53 53" shape-rendering="crispEdges"><path fill="#ffffff" d="M0 0h53v53H0z"/><path stroke="#000000" d="M4 4.5h7m5 0h2m1 0h4m3 0h2m1 0h2m3 0h2m1 0h1m2 0h1m1 0h7M4 5.5h1m5 0h1m5 0h1m8 0h1m1 0h1m1 0h1m1 0h3m3 0h1m1 0h1m2 0h1m5 0h1M4 6.5h1m1 0h3m1 0h1m1 0h4m1 0h1m2 0h1m1 0h3m1 0h1m1 0h1m2 0h1m3 0h1m1 0h1m1 0h1m2 0h1m1 0h3m1 0h1M4 7.5h1m1 0h3m1 0h1m1 0h2m1 0h1m1 0h2m1 0h6m2 0h2m2 0h1m6 0h2m1 0h1m1 0h3m1 0h1M4 8.5h1m1 0h3m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h3m1 0h5m2 0h3m3 0h4m1 0h1m1 0h3m1 0h1M4 9.5h1m5 0h1m1 0h5m2 0h3m2 0h1m3 0h2m1 0h1m2 0h1m2 0h1m4 0h1m5 0h1M4 10.5h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7M12 11.5h2m2 0h1m7 0h1m3 0h2m1 0h1m1 0h1m1 0h1M4 12.5h1m1 0h5m5 0h2m2 0h2m2 0h5m1 0h1m2 0h2m1 0h1m5 0h5M4 13.5h2m1 0h1m1 0h1m3 0h1m1 0h2m2 0h2m1 0h1m1 0h2m1 0h2m1 0h2m1 0h1m1 0h2m2 0h1m3 0h1m2 0h1M4 14.5h1m2 0h4m1 0h1m3 0h2m5 0h1m1 0h1m2 0h1m1 0h1m2 0h3m2 0h1m1 0h1m2 0h2M5 15.5h1m5 0h2m4 0h1m1 0h1m2 0h1m2 0h4m1 0h2m2 0h2m1 0h2m1 0h1m1 0h2m1 0h2M6 16.5h2m2 0h2m1 0h1m1 0h1m3 0h5m1 0h1m2 0h1m1 0h1m1 0h4m1 0h4m2 0h1M5 17.5h2m6 0h2m1 0h1m1 0h2m1 0h2m3 0h1m1 0h2m1 0h2m1 0h1m3 0h4m2 0h1M5 18.5h1m1 0h1m2 0h1m1 0h1m1 0h5m3 0h2m1 0h2m1 0h1m1 0h1m1 0h1m2 0h1m1 0h1m2 0h1m1 0h1m1 0h3m1 0h1M7 19.5h2m5 0h1m1 0h1m3 0h1m1 0h1m1 0h1m1 0h1m1 0h3m2 0h1m1 0h1m1 0h2m1 0h1m4 0h3M6 20.5h1m1 0h1m1 0h2m4 0h1m1 0h1m2 0h1m1 0h1m1 0h1m3 0h1m1 0h3m1 0h1m1 0h2m1 0h2m1 0h1m1 0h1M4 21.5h2m1 0h3m1 0h1m5 0h3m2 0h2m2 0h1m2 0h1m2 0h6m2 0h1m2 0h2m1 0h1m1 0h1M4 22.5h3m3 0h3m5 0h1m2 0h3m3 0h3m1 0h1m1 0h1m2 0h2m1 0h2m2 0h1m1 0h1m2 0h1M4 23.5h4m3 0h1m2 0h2m1 0h1m2 0h1m1 0h1m1 0h2m2 0h7m1 0h1m4 0h1m1 0h2m1 0h1M4 24.5h1m1 0h1m1 0h5m1 0h3m2 0h1m1 0h1m2 0h5m1 0h1m3 0h1m4 0h6M4 25.5h5m3 0h1m2 0h3m1 0h1m1 0h2m1 0h1m3 0h6m2 0h1m2 0h2m3 0h1m1 0h1M4 26.5h3m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m2 0h2m1 0h1m1 0h1m1 0h1m1 0h1m3 0h1m1 0h1m3 0h1m1 0h1m1 0h1m1 0h2m1 0h2M5 27.5h1m2 0h1m3 0h2m1 0h1m1 0h2m2 0h2m1 0h1m3 0h1m2 0h1m1 0h2m1 0h1m3 0h1m3 0h1m1 0h1M6 28.5h1m1 0h6m1 0h2m1 0h1m1 0h1m1 0h1m1 0h5m2 0h1m2 0h1m3 0h1m1 0h5m2 0h2M6 29.5h1m1 0h1m2 0h1m1 0h2m2 0h1m1 0h1m1 0h3m1 0h2m1 0h1m2 0h1m1 0h1m2 0h2m1 0h1m1 0h1M7 30.5h2m1 0h1m4 0h1m2 0h3m2 0h1m4 0h1m2 0h1m2 0h5m3 0h3m3 0h1M8 31.5h1m2 0h1m3 0h2m3 0h3m1 0h2m3 0h1m1 0h1m1 0h2m1 0h1m5 0h7M4 32.5h1m3 0h3m2 0h1m4 0h4m1 0h1m2 0h1m1 0h1m2 0h1m1 0h3m1 0h1m2 0h2m1 0h1M5 33.5h1m8 0h1m2 0h4m3 0h2m3 0h3m4 0h1m3 0h3m1 0h2m2 0h1M4 34.5h2m3 0h5m2 0h1m1 0h1m1 0h1m1 0h2m2 0h1m1 0h1m2 0h1m1 0h4m1 0h1m1 0h1m4 0h1m1 0h1M4 35.5h1m3 0h1m2 0h3m9 0h3m1 0h1m2 0h1m1 0h1m2 0h1m3 0h1m1 0h1m1 0h2m2 0h2M4 36.5h4m2 0h1m1 0h2m1 0h2m1 0h2m1 0h1m1 0h1m2 0h1m2 0h3m1 0h1m1 0h4m1 0h1m1 0h1m2 0h1M4 37.5h1m1 0h2m1 0h1m1 0h1m1 0h1m1 0h1m2 0h1m1 0h3m3 0h2m1 0h1m1 0h1m1 0h7m3 0h1m1 0h1M8 38.5h1m1 0h2m1 0h1m1 0h1m1 0h3m3 0h1m1 0h1m2 0h2m1 0h2m2 0h3m2 0h7M5 39.5h4m2 0h3m3 0h2m1 0h2m1 0h2m2 0h1m3 0h4m1 0h1m9 0h1M4 40.5h1m2 0h2m1 0h3m1 0h1m4 0h1m4 0h6m8 0h1m1 0h7m1 0h1M12 41.5h1m2 0h5m4 0h1m3 0h1m2 0h3m2 0h2m2 0h1m3 0h3M4 42.5h7m4 0h1m2 0h1m1 0h1m1 0h3m1 0h1m1 0h2m1 0h1m2 0h1m2 0h1m2 0h1m1 0h1m1 0h5M4 43.5h1m5 0h1m1 0h2m1 0h1m2 0h2m1 0h2m1 0h1m3 0h1m1 0h3m1 0h5m1 0h1m3 0h1m1 0h1m1 0h1M4 44.5h1m1 0h3m1 0h1m1 0h1m3 0h1m2 0h1m1 0h1m2 0h7m2 0h1m1 0h3m2 0h5m1 0h1m1 0h1M4 45.5h1m1 0h3m1 0h1m1 0h3m2 0h1m2 0h1m1 0h1m2 0h1m1 0h1m8 0h4m1 0h4m1 0h1M4 46.5h1m1 0h3m1 0h1m1 0h1m1 0h3m3 0h2m2 0h1m3 0h2m1 0h13M4 47.5h1m5 0h1m6 0h1m4 0h1m7 0h3m1 0h1m1 0h2m7 0h3M4 48.5h7m1 0h1m2 0h2m1 0h1m1 0h1m2 0h6m2 0h5m1 0h2m1 0h2m3 0h2"/></svg>
+  <header class="brand">
+    <div class="mark" aria-hidden="true">LCV</div>
+    <div>
+      <h1>Apoie Calculadora App</h1>
+      <p class="lede">Apoio direto aos projetos open-source da LCV Ideas &amp; Software.</p>
     </div>
-    <p class="qr-caption">Escaneie no app do banco · qualquer valor aceito</p>
-  </section>
+  </header>
 
-  <section class="card" aria-labelledby="copia-h">
-    <h2 id="copia-h">PIX Copia e Cola</h2>
-    <div class="copy-row">
-      <div class="code-block" id="payload">00020126580014BR.GOV.BCB.PIX0136c9328705-fa51-44c0-b972-bca71e2d06bd5204000053039865802BR5917LEONARDO C VARGAS6014RIO DE JANEIRO62070503***6304D26C</div>
-      <button type="button" id="copy-btn" aria-label="Copiar PIX Copia e Cola">Copiar</button>
+  <section class="panel" aria-labelledby="payment-title">
+    <div class="layout">
+      <div>
+        <h2 id="payment-title">Pagamento seguro com SumUp</h2>
+        <p class="muted">Informe o valor, gere o checkout e conclua o apoio no widget seguro abaixo.</p>
+
+        <form id="support-form">
+          <label>
+            Valor em reais
+            <input id="amount" name="amount" inputmode="decimal" autocomplete="off" placeholder="25,00" required />
+          </label>
+          <div class="amounts" aria-label="Valores sugeridos">
+            <button class="amount-btn" type="button" data-amount="10">R$ 10</button>
+            <button class="amount-btn" type="button" data-amount="25">R$ 25</button>
+            <button class="amount-btn" type="button" data-amount="50">R$ 50</button>
+            <button class="amount-btn" type="button" data-amount="100">R$ 100</button>
+          </div>
+          <label>
+            Nome
+            <input id="supporter-name" name="name" autocomplete="name" placeholder="Seu nome" />
+          </label>
+          <label>
+            E-mail
+            <input id="email" name="email" type="email" autocomplete="email" placeholder="voce@email.com" required />
+          </label>
+          <button id="start-payment" class="primary" type="submit">Gerar pagamento</button>
+        </form>
+
+        <div id="status" class="status" role="status" aria-live="polite" hidden></div>
+        <a class="repo-link" href="https://github.com/LCV-Ideas-Software/calculadora-app" target="_blank" rel="noopener noreferrer">Ver repositório do projeto</a>
+      </div>
+
+      <div id="widget-shell" class="widget-shell" hidden>
+        <div id="sumup-card"></div>
+      </div>
     </div>
-  </section>
 
-  <section class="card" aria-labelledby="key-h">
-    <h2 id="key-h">Chave PIX (aleatória)</h2>
-    <div class="copy-row">
-      <div class="code-block" id="pixkey">c9328705-fa51-44c0-b972-bca71e2d06bd</div>
-      <button type="button" id="copy-key" aria-label="Copiar chave PIX">Copiar</button>
+    <div class="note">
+      Os dados de cartão são coletados e processados pela SumUp. Esta página solicita apenas os dados necessários para criar um checkout seguro.
     </div>
-  </section>
-
-  <section class="card" aria-labelledby="how-h">
-    <h2 id="how-h">Como pagar</h2>
-    <ol>
-      <li><strong>Abra o app do seu banco</strong> e vá em PIX.</li>
-      <li><strong>QR Code:</strong> escaneie a imagem acima · <strong>ou Copia e Cola:</strong> cole o código gerado · <strong>ou Chave:</strong> use a chave aleatória.</li>
-      <li>O recebedor aparecerá como <strong>LEONARDO CARDOZO VARGAS</strong>.</li>
-      <li>Defina o valor que quiser e confirme.</li>
-    </ol>
   </section>
 
   <footer>
-    <p>Recebedor: <strong>LEONARDO C VARGAS</strong> · Cidade: <strong>RIO DE JANEIRO</strong></p>
-    <p><a href="https://github.com/lcv-leo">Perfil GitHub</a> · <a href="https://github.com/sponsors/lcv-leo">GitHub Sponsors</a></p>
+    <p>LCV Ideas &amp; Software - Calculadora App</p>
   </footer>
 </main>
 
 <script>
 (function () {
-  function setupCopy(btnId, srcId) {
-    var btn = document.getElementById(btnId);
-    var src = document.getElementById(srcId);
-    if (!btn || !src) return;
-    btn.addEventListener('click', function () {
-      var text = src.textContent.trim();
-      function done() {
-        var prev = btn.textContent;
-        btn.textContent = 'Copiado';
-        btn.classList.add('copied');
-        setTimeout(function () {
-          btn.textContent = prev;
-          btn.classList.remove('copied');
-        }, 1500);
+  'use strict';
+
+  var PROJECT_NAME = 'Calculadora App';
+  var API_BASE_URL = 'https://reflexosdaalma.blog/api';
+  var SDK_URL = 'https://gateway.sumup.com/gateway/ecom/card/v2/sdk.js';
+  var form = document.getElementById('support-form');
+  var amountInput = document.getElementById('amount');
+  var nameInput = document.getElementById('supporter-name');
+  var emailInput = document.getElementById('email');
+  var startButton = document.getElementById('start-payment');
+  var statusBox = document.getElementById('status');
+  var widgetShell = document.getElementById('widget-shell');
+  var amountButtons = Array.prototype.slice.call(document.querySelectorAll('.amount-btn'));
+  var widgetInstance = null;
+  var sdkPromise = null;
+  var pollingTimer = null;
+
+  function setStatus(message, kind) {
+    statusBox.hidden = false;
+    statusBox.className = 'status' + (kind ? ' ' + kind : '');
+    statusBox.textContent = message;
+  }
+
+  function setBusy(isBusy) {
+    startButton.disabled = isBusy;
+    startButton.textContent = isBusy ? 'Preparando...' : 'Gerar pagamento';
+  }
+
+  function parseAmount(value) {
+    var normalized = String(value || '').replace(/\s/g, '').replace(/\./g, '').replace(',', '.');
+    var amount = Number(normalized);
+    return Number.isFinite(amount) ? Math.round(amount * 100) / 100 : 0;
+  }
+
+  function formatAmount(value) {
+    return Number(value).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function splitName(value) {
+    var parts = String(value || '').trim().split(/\s+/).filter(Boolean);
+    if (!parts.length) return { firstName: 'Apoiador', lastName: PROJECT_NAME };
+    return { firstName: parts.shift(), lastName: parts.join(' ') || PROJECT_NAME };
+  }
+
+  function loadSdk() {
+    if (window.SumUpCard) return Promise.resolve();
+    if (sdkPromise) return sdkPromise;
+    sdkPromise = new Promise(function (resolve, reject) {
+      var existing = document.querySelector('script[src="' + SDK_URL + '"]');
+      if (existing) {
+        existing.addEventListener('load', resolve, { once: true });
+        existing.addEventListener('error', function () { reject(new Error('Falha ao carregar o widget da SumUp.')); }, { once: true });
+        return;
       }
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(done, fallback);
-      } else {
-        fallback();
-      }
-      function fallback() {
-        var ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.left = '-9999px';
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        try { document.execCommand('copy'); done(); } catch (e) {}
-        document.body.removeChild(ta);
+      var script = document.createElement('script');
+      script.src = SDK_URL;
+      script.async = true;
+      script.onload = resolve;
+      script.onerror = function () { reject(new Error('Falha ao carregar o widget da SumUp.')); };
+      document.head.appendChild(script);
+    });
+    return sdkPromise;
+  }
+
+  function normalizeMethod(method) {
+    if (typeof method === 'string') return method.toLowerCase();
+    if (method && typeof method.id === 'string') return method.id.toLowerCase();
+    return '';
+  }
+
+  function startPolling(checkoutId) {
+    if (pollingTimer) window.clearInterval(pollingTimer);
+    var attempts = 0;
+    var check = function () {
+      attempts += 1;
+      fetch(API_BASE_URL + '/sumup/checkout/' + encodeURIComponent(checkoutId) + '/status', { credentials: 'omit' })
+        .then(function (res) { return res.ok ? res.json() : null; })
+        .then(function (data) {
+          if (!data || !data.status) return;
+          var status = String(data.status).toUpperCase();
+          if (status === 'SUCCESSFUL' || status === 'PAID') {
+            window.clearInterval(pollingTimer);
+            pollingTimer = null;
+            setStatus('Pagamento confirmado. Obrigado pelo apoio!', 'success');
+          } else if (status === 'FAILED' || status === 'EXPIRED' || status === 'CANCELLED') {
+            window.clearInterval(pollingTimer);
+            pollingTimer = null;
+            setStatus('Pagamento não concluído. Você pode tentar novamente.', 'error');
+          } else if (attempts > 150) {
+            window.clearInterval(pollingTimer);
+            pollingTimer = null;
+            setStatus('Pagamento enviado. A confirmação pode levar mais alguns instantes na SumUp.');
+          }
+        })
+        .catch(function () {
+          if (attempts > 150) {
+            window.clearInterval(pollingTimer);
+            pollingTimer = null;
+          }
+        });
+    };
+    check();
+    pollingTimer = window.setInterval(check, 4000);
+  }
+
+  function mountWidget(checkoutId, amount, email) {
+    if (!window.SumUpCard || typeof window.SumUpCard.mount !== 'function') {
+      throw new Error('Widget da SumUp indisponível no navegador.');
+    }
+    if (widgetInstance && typeof widgetInstance.unmount === 'function') {
+      widgetInstance.unmount();
+    }
+    widgetShell.hidden = false;
+    widgetInstance = window.SumUpCard.mount({
+      id: 'sumup-card',
+      checkoutId: checkoutId,
+      email: email,
+      amount: amount.toFixed(2),
+      currency: 'BRL',
+      locale: 'pt-BR',
+      country: 'BR',
+      donateSubmitButton: true,
+      showEmail: false,
+      showFooter: true,
+      showSubmitButton: true,
+      onPaymentMethodsLoad: function (methods) {
+        var ids = Array.isArray(methods) ? methods.map(normalizeMethod).filter(Boolean) : [];
+        var cardOnly = ids.filter(function (method) { return method === 'card'; });
+        return cardOnly.length ? cardOnly : ids;
+      },
+      onLoad: function () {
+        setStatus('Checkout pronto. Conclua o pagamento no widget da SumUp.');
+      },
+      onResponse: function (type, body) {
+        if (type === 'sent') {
+          setStatus('Pagamento enviado para processamento.');
+          startPolling(checkoutId);
+          return;
+        }
+        if (type === 'auth-screen') {
+          setStatus('Siga a autenticação exibida pela SumUp para concluir.');
+          startPolling(checkoutId);
+          return;
+        }
+        if (type === 'invalid') {
+          setStatus('Revise os dados informados no widget e tente novamente.', 'error');
+          return;
+        }
+        if (type === 'success') {
+          setStatus('Pagamento enviado. Confirmando com a SumUp...');
+          startPolling(checkoutId);
+          return;
+        }
+        if (type === 'fail' || type === 'error') {
+          var message = body && (body.message || body.error_message || body.error);
+          setStatus(message || 'A SumUp não concluiu o pagamento. Tente novamente.', 'error');
+        }
       }
     });
   }
-  setupCopy('copy-btn', 'payload');
-  setupCopy('copy-key', 'pixkey');
+
+  amountButtons.forEach(function (button) {
+    button.setAttribute('aria-pressed', 'false');
+    button.addEventListener('click', function () {
+      amountButtons.forEach(function (btn) { btn.setAttribute('aria-pressed', 'false'); });
+      button.setAttribute('aria-pressed', 'true');
+      amountInput.value = formatAmount(Number(button.dataset.amount || 0));
+      amountInput.focus();
+    });
+  });
+
+  amountInput.addEventListener('input', function () {
+    amountButtons.forEach(function (btn) { btn.setAttribute('aria-pressed', 'false'); });
+  });
+
+  form.addEventListener('submit', function (event) {
+    event.preventDefault();
+    var amount = parseAmount(amountInput.value);
+    var email = String(emailInput.value || '').trim();
+    if (amount < 1 || amount > 10000) {
+      setStatus('Informe um valor entre R$ 1,00 e R$ 10.000,00.', 'error');
+      return;
+    }
+    if (!email || !emailInput.validity.valid) {
+      setStatus('Informe um e-mail válido para gerar o checkout.', 'error');
+      return;
+    }
+
+    var name = splitName(nameInput.value);
+    setBusy(true);
+    setStatus('Criando checkout seguro na SumUp...');
+
+    fetch(API_BASE_URL + '/sumup/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'omit',
+      body: JSON.stringify({
+        baseAmount: amount,
+        coverFees: false,
+        firstName: name.firstName,
+        lastName: name.lastName,
+        email: email,
+        redirectUrl: window.location.href.split('#')[0],
+        sourceProject: PROJECT_NAME
+      })
+    })
+      .then(function (res) {
+        return res.json().then(function (data) {
+          if (!res.ok) throw new Error(data && data.error ? data.error : 'Falha ao criar checkout.');
+          return data;
+        });
+      })
+      .then(function (data) {
+        if (!data.checkoutId) throw new Error('A SumUp não retornou um checkout válido.');
+        return loadSdk().then(function () {
+          mountWidget(data.checkoutId, amount, email);
+        });
+      })
+      .catch(function (error) {
+        setStatus(error && error.message ? error.message : 'Não foi possível iniciar o pagamento.', 'error');
+      })
+      .finally(function () {
+        setBusy(false);
+      });
+  });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the temporary SumUp documentation link with an embedded SumUp Card Widget flow
- create a checkout through the secure MainSite API before mounting the widget
- keep payment credentials out of the static Sponsors Page

## Validation
- no PIX/lcv-leo/developer-doc CTA remains in site/index.html
- SumUp SDK script and SumUpCard.mount are present
- JavaScript syntax checked with node --check on the generated page script