### PR TITLE
ci(deps): align github/codeql-action refs and group Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       prefix: "deps"
       include: "scope"
     open-pull-requests-limit: 10
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,13 +41,13 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
           dependency-caching: true
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           path: scorecard-results.sarif
           retention-days: 5
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Why

`github/codeql-action` is consumed via three pinned subpath refs (`init`, `analyze`, `upload-sarif`).
Dependabot bumps each subpath in a separate PR, and codeql-action now hard-fails the `analyze`
step when `init` and `analyze` run different versions inside the same workflow
(`Loaded a configuration file for version 'X', but running version 'Y'`). A single-subpath bump
PR therefore can never go green, and merging one alone breaks CodeQL on the default branch.

## What

- Align every `github/codeql-action/*` ref to the same pin
  `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (v4.36.3), keeping the version comment.
- Add a Dependabot `groups` entry (`github/codeql-action*`) to the `github-actions`
  ecosystem so future codeql-action bumps arrive as one internally consistent PR.

Dependabot will auto-close its now-obsolete per-subpath PRs once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
