### PR TITLE
fix: bound Socket scan commit metadata

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -56,10 +56,12 @@ jobs:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOCKET_PR_NUMBER: ${{ github.event.pull_request.number }}
+          SOCKET_SCAN_COMMIT_MESSAGE: ${{ github.sha }}
         run: |
           socketcli \
             --target-path "$GITHUB_WORKSPACE" \
             --scm github \
+            --commit-message "$SOCKET_SCAN_COMMIT_MESSAGE" \
             --pr-number "$SOCKET_PR_NUMBER"
 
   socket-security-branch-audit:
@@ -99,7 +101,9 @@ jobs:
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOCKET_SCAN_COMMIT_MESSAGE: ${{ github.sha }}
         run: |
           socketcli \
             --target-path "$GITHUB_WORKSPACE" \
-            --scm github
+            --scm github \
+            --commit-message "$SOCKET_SCAN_COMMIT_MESSAGE"

--- a/functions/api/__tests__/socket-workflow.test.mjs
+++ b/functions/api/__tests__/socket-workflow.test.mjs
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+
+const workflow = readFileSync(
+    new URL('../../../.github/workflows/socket.yml', import.meta.url),
+    'utf8',
+);
+
+const scanSteps = workflow
+    .split('      - name: Run Socket Security Scan (audit)')
+    .slice(1);
+
+it('bounds the commit message sent by both Socket Security scans', () => {
+    expect(scanSteps).toHaveLength(2);
+
+    for (const scanStep of scanSteps) {
+        expect(scanStep).toContain(
+            'SOCKET_SCAN_COMMIT_MESSAGE: ${{ github.sha }}',
+        );
+        expect(scanStep).toContain(
+            '--commit-message "$SOCKET_SCAN_COMMIT_MESSAGE"',
+        );
+    }
+});


### PR DESCRIPTION
## What changed

- pass the bounded 40-character `github.sha` as `--commit-message` in both Socket scan jobs
- add a regression test that requires the bounded override in both workflow paths

## Root cause

Socket Security run 29013215348 placed a 30,911-byte Dependabot merge message in the `commit_message` query parameter, creating an approximately 40 KB request target and receiving HTTP 431. The current upstream CLI/SDK still serializes this field into the URL, so a package bump alone does not resolve the failure.

## Validation

- regression test failed against the base workflow and passes after the fix
- full suite: 13 tests
- Biome and production build
- actionlint and diff check
- two-round cross-review: unanimous READY (session `8b8fbae6-3cd5-45a3-9c9d-83d0f3f5c0d5`)
