### PR TITLE
fix: unblock Dependabot security updates

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/**"
       - ".github/dependabot.yml"
+      - "socketsecurity-requirements.txt"
       - "SECURITY.md"
   schedule:
     - cron: "37 8 * * 1"

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Socket CLI
-        run: python -m pip install --disable-pip-version-check --require-hashes -r .github/socketsecurity-requirements.txt
+        run: python -m pip install --disable-pip-version-check --require-hashes -r socketsecurity-requirements.txt
 
       - name: Validate Socket API key
         env:
@@ -86,7 +86,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Socket CLI
-        run: python -m pip install --disable-pip-version-check --require-hashes -r .github/socketsecurity-requirements.txt
+        run: python -m pip install --disable-pip-version-check --require-hashes -r socketsecurity-requirements.txt
 
       - name: Validate Socket API key
         env:

--- a/socketsecurity-requirements.txt
+++ b/socketsecurity-requirements.txt
@@ -194,9 +194,9 @@ socketsecurity==2.2.90 \
     --hash=sha256:a06798d2d8c24465fd75b53105cb6ad1022d37c2c4771a85a0fb2466bce3d11d \
     --hash=sha256:a535eaabfd0bc0c78d1dcdeb84859e0bd811fbd9f2f8aa96d1169d586f07e991
     # via -r C:/Users/leona/AppData/Local/Temp/socketsecurity-req.in
-soupsieve==2.8.3 \
-    --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
-    --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+soupsieve==2.8.4 \
+    --hash=sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e \
+    --hash=sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65
     # via beautifulsoup4
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
@@ -212,4 +212,3 @@ wcwidth==0.7.0 \
     --hash=sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2 \
     --hash=sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0
     # via prettytable
-


### PR DESCRIPTION
## What changed

- moves the hash-locked Socket CLI requirements file out of `.github` to the repository root;
- updates `soupsieve` from vulnerable `2.8.3` to patched `2.8.4` with the official wheel and sdist hashes;
- updates every Socket workflow reference to the root lock;
- makes OpenSSF Scorecard run on future changes to that lock.

## Root cause

The Dependabot security updater successfully resolved and generated the `soupsieve 2.8.4` change, then failed only when creating the PR with HTTP 400: `The request contains invalid or unauthorized changes`. Non-`github-actions` ecosystems currently lack the `workflows` scope needed to modify files under `.github`, matching [dependabot-core#15237](https://github.com/dependabot/dependabot-core/issues/15237).

Keeping the lock under `.github` would leave future security updates blocked. Moving it to the root removes that protected-path failure instead of dismissing the alerts.

## Validation

- `actionlint 1.7.12` passed for `socket.yml` and `scorecard.yml`;
- `pip install --dry-run --ignore-installed --require-hashes` passed and selected `soupsieve 2.8.4`;
- official PyPI hashes match the staged lock;
- `git diff --check` and the exact staged-scope audit passed;
- Lint, Biome, 13 tests, build, and Prettier passed.
- Ultrabrain review completed and cross-review converged unanimously.

## Follow-up

This PR is intentionally a draft. The Dependabot and Scorecard alerts remain open on `main` until this change is merged and a fresh analysis is uploaded. After merge, the organization-level Dependabot and code-scanning alert counts must be checked again; no alert is being dismissed.