### PR TITLE
ci: roll out guarded Dependabot controller

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,7 +35,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@c846bc77cbeb38dcf5fb4b8c798dc75227b65f04
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@06078610da5edd1c6d020db205c69d3cd580fcf9
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## What changed

- Pins the reusable Dependabot controller to the fully reviewed commit 06078610da5edd1c6d020db205c69d3cd580fcf9.
- No workflow_run producer names were changed.

## Why

This is the repository-specific wrapper rollout of the guarded organization controller after the central implementation and canary validation. A full commit SHA prevents mutable-reference drift.

## Safety boundaries retained

- Workflow-level and job-level permissions remain exactly write-all, per organization policy.
- The dependabot-automation environment and separation between github.token and LCV_AUTOMATION_TOKEN remain unchanged.
- FIFO serialization remains queue: max with cancel-in-progress: false.
- The repository-specific required_checks_json allowlist remains unchanged and parses as valid JSON.
- No application, deployment, database, release, or data-handling file is changed.

## Validation

- Exact base: e71614b054bc25f32173d38d52b4154315f9ef57
- Exact signed head: b188bf8f6287b58038d013a87910c28a822e6584
- Central commit signature: GitHub verified and valid.
- yq v4.53.3: YAML parsed; permissions, tokens, environment, FIFO and required-check invariants checked.
- Zizmor core v1.28.0: official Windows release asset SHA-256 verified; offline auditor persona with strict collection and collect-all reported no active findings.
- git diff --check: passed.
- actionlint v1.7.12: only the known parser gap for GitHub concurrency queue: max (actionlint issue #657); no independent diagnostic.
- git verify-commit: passed.

## Rollout state

Draft only. This PR has not been merged, and the Dependabot Automerge workflow has not been enabled or manually dispatched.