### PR TITLE
ci: update Dependabot controller pin

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,7 +35,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@06078610da5edd1c6d020db205c69d3cd580fcf9
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@d8f67ca034edb6173ce9baaff41ccb320ef4bf2d
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## O que mudou

- Atualiza somente o pin imutável do controlador de automerge do Dependabot para `d8f67ca034edb6173ce9baaff41ccb320ef4bf2d`.
- Preserva `permissions: write-all`, os gatilhos, requisitos e toda a configuração existente.

## Motivo

O novo controlador reconhece exclusivamente os manifests canônicos `socketsecurity-requirements.in` e `socketsecurity-requirements.txt`, mantendo as validações fail-closed para caminhos não permitidos.

## Validação

- YAML analisado com `yq`.
- `zizmor --offline --persona=auditor --strict-collection` sem achados ativos no workflow.
- `actionlint` sem diagnósticos além da chave oficial `concurrency.queue`, ainda não reconhecida pela versão local.
- Diff verificado: uma inserção e uma remoção em um único arquivo.