### PR TITLE
feat(oraculo): migrate Gemini transport to Vertex AI service-account auth (v04.03.00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [v04.03.00] - 2026-08-08
+
+**Minor — migra o transporte do Oráculo IA do endpoint AI Studio (API key) para o Vertex AI (Gemini Enterprise Agent Platform) com autenticação de service account.**
+
+### Alterado
+
+- O endpoint `/api/oraculo` passa a chamar `aiplatform.googleapis.com` (projeto `lcv-ideas-and-software`, location `global`; overrides via `VERTEX_PROJECT`/`VERTEX_LOCATION`) autenticando com service account (`VERTEX_SA_KEY`) via JWT RS256 assinado com WebCrypto e trocado por access token OAuth2. Com isso o consumo Gemini deixa o plano pré-pago do AI Studio e passa a faturar no pós-pago padrão do Cloud Billing. Prompts, cadeia de fallbacks, telemetria e contrato de resposta permanecem intactos.
+
+### Adicionado
+
+- Novo módulo `functions/api/_shared/vertex.ts`: client mínimo que espelha a superfície usada do SDK (`models.generateContent`/`models.countTokens`), com cache de access token por identidade de chave, single-flight para mints concorrentes e erros diagnósticos (status HTTP + trecho do corpo + causa OAuth).
+
+### Removido
+
+- Dependência `@google/genai`, órfã após a migração do transporte, e o override transitivo de `protobufjs` que existia exclusivamente pela cadeia dela. O override de `undici` permanece intocado (config pré-existente sem rationale documentado).
+
+### Testes
+
+- 17 testes novos do client Vertex — claims e assinatura do JWT verificada criptograficamente com a chave pública, mapeamento SDK→REST, URL global/regional, cache/expiração com margem, single-flight, isolamento por identidade de chave e caminhos de erro diagnósticos — e 3 novos do handler (construção do client, overrides de env, secret ausente). Suíte total: 71/71.
+
 ## [v04.02.04] - 2026-08-03
 
 **Patch — corrige a precedência dos limiares MAPE customizados e resolve os findings de qualidade do motor de cálculo.**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Calculadora Financeira** — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.
 
-**Status.** Stable. Current release: **v04.02.04**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v04.03.00**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v04.03.00`**                      | **Vertex AI transport migration.** Oráculo IA now calls Vertex AI with service-account auth (WebCrypto RS256 JWT -> OAuth2, per-key token cache, single-flight), moving Gemini billing from AI Studio prepaid credits to standard postpaid Cloud billing; prompts, fallback chain, telemetry and the GEMINI_MODEL override unchanged.                             |
 | **`v04.02.04`**                      | **Backtest threshold precedence fix.** Custom MAPE thresholds now follow D1 > finite payload > valid environment > default, preserving percentage-point scale; focused tests cover every tier and prove that a PTAX cache hit performs no external request. |
 | **`v04.02.03`**                      | **Dependency security patch.** Resolves GHSA-j3f2-48v5-ccww / CVE-2026-59877 by moving the transitive `protobufjs` override used by `@google/genai` from 7.6.3 to 7.6.5. |
 | **`v04.02.02`**                      | **Cross-review finding fixed.** AI telemetry (insert + LGPD prune of ai_usage_logs) now returns its Promise and is registered via context.waitUntil at both call sites (post-response execution guarantee); fallback-chain and telemetry tests added. Shipped under formal unanimous cross-review ALL READY (caller + 5 peers).  |

--- a/functions/api/__tests__/oraculo-model.test.mjs
+++ b/functions/api/__tests__/oraculo-model.test.mjs
@@ -2,10 +2,15 @@ import { expect, it, vi } from 'vitest';
 import { createD1Stub } from './helpers/d1-stub.mjs';
 
 const captured = vi.hoisted(() => []);
+const ctorCaptured = vi.hoisted(() => []);
 const mockState = vi.hoisted(() => ({ failAdvanced: false }));
 
-vi.mock('@google/genai', () => ({
-  GoogleGenAI: class {
+vi.mock('../_shared/vertex.ts', () => ({
+  VertexGenAI: class {
+    constructor(opts) {
+      ctorCaptured.push(opts);
+    }
+
     models = {
       countTokens: async () => ({ totalTokens: 100 }),
       generateContent: async (args) => {
@@ -25,6 +30,8 @@ vi.mock('@google/genai', () => ({
   },
 }));
 
+const SA_FAKE = '{"client_email":"t@p.iam.gserviceaccount.com"}';
+
 const { onRequestPost } = await import('../oraculo.ts');
 
 it('quando o candidato advanced é rejeitado, o fallback chain serve via compat (sem falha dura)', async () => {
@@ -38,7 +45,7 @@ it('quando o candidato advanced é rejeitado, o fallback chain serve via compat 
     });
     const res = await onRequestPost({
       request: req,
-      env: { GEMINI_API_KEY: 'test-key', BIGDATA_DB: createD1Stub() },
+      env: { VERTEX_SA_KEY: SA_FAKE, BIGDATA_DB: createD1Stub() },
     });
     expect(res.status).toBe(200);
     // O advanced (com thinkingConfig) foi tentado e rejeitado; o compat (sem thinkingConfig) serviu.
@@ -61,7 +68,7 @@ it('usa gemini-3.5-flash como default e config idiomática 3.x no primeiro candi
   });
   const res = await onRequestPost({
     request: req,
-    env: { GEMINI_API_KEY: 'test-key', BIGDATA_DB: createD1Stub() },
+    env: { VERTEX_SA_KEY: SA_FAKE, BIGDATA_DB: createD1Stub() },
   });
   expect(res.status).toBe(200);
   expect(captured.length).toBeGreaterThan(0);
@@ -103,7 +110,7 @@ it('registra a telemetria de IA (insert+prune de ai_usage_logs) em context.waitU
   });
   const res = await onRequestPost({
     request: req,
-    env: { GEMINI_API_KEY: 'test-key', BIGDATA_DB: db },
+    env: { VERTEX_SA_KEY: SA_FAKE, BIGDATA_DB: db },
     waitUntil: (p) => waited.push(p),
   });
   expect(res.status).toBe(200);
@@ -124,7 +131,59 @@ it('mantém o override via env.GEMINI_MODEL', async () => {
   });
   await onRequestPost({
     request: req,
-    env: { GEMINI_API_KEY: 'test-key', GEMINI_MODEL: 'modelo-custom', BIGDATA_DB: createD1Stub() },
+    env: { VERTEX_SA_KEY: SA_FAKE, GEMINI_MODEL: 'modelo-custom', BIGDATA_DB: createD1Stub() },
   });
   expect(captured[0].model).toBe('modelo-custom');
+});
+
+it('constrói o client Vertex com a SA do env e projeto/location padrão', async () => {
+  ctorCaptured.length = 0;
+  const req = new Request('https://calc.lcv.app.br/api/oraculo', {
+    method: 'POST',
+    headers: { Origin: 'https://calc.lcv.app.br', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ transacao: { moeda: 'USD' } }),
+  });
+  await onRequestPost({
+    request: req,
+    env: { VERTEX_SA_KEY: SA_FAKE, BIGDATA_DB: createD1Stub() },
+  });
+  expect(ctorCaptured).toHaveLength(1);
+  expect(ctorCaptured[0].saKeyJson).toBe(SA_FAKE);
+  expect(ctorCaptured[0].project).toBe('lcv-ideas-and-software');
+  expect(ctorCaptured[0].location).toBe('global');
+});
+
+it('permite override de projeto e location via env (VERTEX_PROJECT/VERTEX_LOCATION)', async () => {
+  ctorCaptured.length = 0;
+  const req = new Request('https://calc.lcv.app.br/api/oraculo', {
+    method: 'POST',
+    headers: { Origin: 'https://calc.lcv.app.br', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ transacao: { moeda: 'USD' } }),
+  });
+  await onRequestPost({
+    request: req,
+    env: {
+      VERTEX_SA_KEY: SA_FAKE,
+      VERTEX_PROJECT: 'outro-projeto',
+      VERTEX_LOCATION: 'us-central1',
+      BIGDATA_DB: createD1Stub(),
+    },
+  });
+  expect(ctorCaptured[0].project).toBe('outro-projeto');
+  expect(ctorCaptured[0].location).toBe('us-central1');
+});
+
+it('retorna 500 amigável quando VERTEX_SA_KEY não está configurado', async () => {
+  const req = new Request('https://calc.lcv.app.br/api/oraculo', {
+    method: 'POST',
+    headers: { Origin: 'https://calc.lcv.app.br', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ transacao: { moeda: 'USD' } }),
+  });
+  const res = await onRequestPost({
+    request: req,
+    env: { BIGDATA_DB: createD1Stub() },
+  });
+  expect(res.status).toBe(500);
+  const body = await res.json();
+  expect(body.erro).toMatch(/não configurou/);
 });

--- a/functions/api/__tests__/vertex-client.test.mjs
+++ b/functions/api/__tests__/vertex-client.test.mjs
@@ -1,0 +1,316 @@
+import { expect, it } from 'vitest';
+
+import { VertexGenAI } from '../_shared/vertex.ts';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const te = new TextEncoder();
+
+function b64urlToBuf(s) {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  return Uint8Array.from(Buffer.from(b64, 'base64'));
+}
+
+function b64urlToJson(s) {
+  return JSON.parse(Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+}
+
+async function makeTestSa(kid) {
+  const pair = await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+    true,
+    ['sign', 'verify'],
+  );
+  const pkcs8 = Buffer.from(await crypto.subtle.exportKey('pkcs8', pair.privateKey)).toString('base64');
+  const pem = `-----BEGIN PRIVATE KEY-----\n${pkcs8.match(/.{1,64}/g).join('\n')}\n-----END PRIVATE KEY-----\n`;
+  return {
+    publicKey: pair.publicKey,
+    saJson: JSON.stringify({
+      type: 'service_account',
+      project_id: 'proj-x',
+      private_key_id: kid,
+      private_key: pem,
+      client_email: `${kid}@proj-x.iam.gserviceaccount.com`,
+      token_uri: 'https://oauth2.test.invalid/token',
+    }),
+  };
+}
+
+function jsonResponse(status, payload) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+function makeFetchMock({ tokenPayload, apiPayload, tokenStatus = 200, apiStatus = 200, tokenDelay } = {}) {
+  const calls = { token: [], api: [] };
+  const fetchImpl = async (url, init) => {
+    if (String(url).includes('oauth2.test.invalid')) {
+      calls.token.push({ url: String(url), init });
+      if (tokenDelay) await tokenDelay();
+      return jsonResponse(tokenStatus, tokenPayload ?? { access_token: 'tok-1', expires_in: 3600, token_type: 'Bearer' });
+    }
+    calls.api.push({ url: String(url), init });
+    return jsonResponse(apiStatus, apiPayload ?? { candidates: [{ content: { parts: [{ text: 'ok' }] } }], usageMetadata: { promptTokenCount: 1 } });
+  };
+  return { fetchImpl, calls };
+}
+
+function client(sa, mock, extra = {}) {
+  return new VertexGenAI({
+    saKeyJson: sa.saJson,
+    project: 'proj-x',
+    location: 'global',
+    fetchImpl: mock.fetchImpl,
+    ...extra,
+  });
+}
+
+// ── Autenticação ─────────────────────────────────────────────────────────────
+
+it('minta JWT RS256 com header/claims do fluxo oficial e troca por access token no token_uri', async () => {
+  const sa = await makeTestSa('kid-claims');
+  const mock = makeFetchMock();
+  await client(sa, mock).models.countTokens({ model: 'm', contents: 'oi' });
+
+  expect(mock.calls.token).toHaveLength(1);
+  const req = mock.calls.token[0];
+  expect(req.url).toBe('https://oauth2.test.invalid/token');
+  expect(req.init.method).toBe('POST');
+  expect(req.init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+
+  const params = new URLSearchParams(req.init.body);
+  expect(params.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+
+  const assertion = params.get('assertion');
+  const [h, c, s] = assertion.split('.');
+  expect(b64urlToJson(h)).toEqual({ alg: 'RS256', typ: 'JWT', kid: 'kid-claims' });
+
+  const claims = b64urlToJson(c);
+  const nowSec = Math.floor(Date.now() / 1000);
+  expect(claims.iss).toBe('kid-claims@proj-x.iam.gserviceaccount.com');
+  expect(claims.scope).toBe('https://www.googleapis.com/auth/cloud-platform');
+  expect(claims.aud).toBe('https://oauth2.test.invalid/token');
+  expect(claims.exp - claims.iat).toBe(3600);
+  expect(claims.iat).toBeLessThanOrEqual(nowSec);
+  expect(claims.iat).toBeGreaterThanOrEqual(nowSec - 90);
+
+  // Assinatura verificada de fato com a chave pública do par gerado no teste.
+  const valid = await crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    sa.publicKey,
+    b64urlToBuf(s),
+    te.encode(`${h}.${c}`),
+  );
+  expect(valid).toBe(true);
+});
+
+it('envia Authorization Bearer e monta a URL global do generateContent', async () => {
+  const sa = await makeTestSa('kid-url-global');
+  const mock = makeFetchMock();
+  await client(sa, mock).models.generateContent({ model: 'gemini-3.5-flash', contents: 'oi' });
+
+  expect(mock.calls.api).toHaveLength(1);
+  expect(mock.calls.api[0].url).toBe(
+    'https://aiplatform.googleapis.com/v1/projects/proj-x/locations/global/publishers/google/models/gemini-3.5-flash:generateContent',
+  );
+  expect(mock.calls.api[0].init.headers.Authorization).toBe('Bearer tok-1');
+});
+
+it('usa o endpoint regional quando location não é global', async () => {
+  const sa = await makeTestSa('kid-url-regional');
+  const mock = makeFetchMock();
+  const ai = new VertexGenAI({
+    saKeyJson: sa.saJson,
+    project: 'proj-x',
+    location: 'us-central1',
+    fetchImpl: mock.fetchImpl,
+  });
+  await ai.models.generateContent({ model: 'm', contents: 'oi' });
+  expect(mock.calls.api[0].url).toBe(
+    'https://us-central1-aiplatform.googleapis.com/v1/projects/proj-x/locations/us-central1/publishers/google/models/m:generateContent',
+  );
+});
+
+// ── Mapeamento SDK → REST ────────────────────────────────────────────────────
+
+it('mapeia config no formato do SDK para o corpo REST do Vertex', async () => {
+  const sa = await makeTestSa('kid-map');
+  const mock = makeFetchMock();
+  const safetySettings = [{ category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' }];
+  await client(sa, mock).models.generateContent({
+    model: 'm',
+    contents: 'pergunta',
+    config: {
+      temperature: 0.3,
+      topP: 0.8,
+      maxOutputTokens: 8192,
+      thinkingConfig: { thinkingLevel: 'low' },
+      safetySettings,
+      systemInstruction: 'voce é analista',
+    },
+  });
+
+  const body = JSON.parse(mock.calls.api[0].init.body);
+  expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'pergunta' }] }]);
+  expect(body.generationConfig).toEqual({
+    temperature: 0.3,
+    topP: 0.8,
+    maxOutputTokens: 8192,
+    thinkingConfig: { thinkingLevel: 'low' },
+  });
+  expect(body.systemInstruction).toEqual({ role: 'user', parts: [{ text: 'voce é analista' }] });
+  expect(body.safetySettings).toEqual(safetySettings);
+  expect(body.config).toBeUndefined();
+});
+
+it('omite campos ausentes do config sem enviar chaves vazias', async () => {
+  const sa = await makeTestSa('kid-map-min');
+  const mock = makeFetchMock();
+  await client(sa, mock).models.generateContent({ model: 'm', contents: 'x' });
+  const body = JSON.parse(mock.calls.api[0].init.body);
+  expect(body.generationConfig).toBeUndefined();
+  expect(body.systemInstruction).toBeUndefined();
+  expect(body.safetySettings).toBeUndefined();
+});
+
+it('aceita contents já estruturado (array) com passthrough', async () => {
+  const sa = await makeTestSa('kid-map-arr');
+  const mock = makeFetchMock();
+  const contents = [{ role: 'user', parts: [{ text: 'a' }, { text: 'b' }] }];
+  await client(sa, mock).models.generateContent({ model: 'm', contents });
+  const body = JSON.parse(mock.calls.api[0].init.body);
+  expect(body.contents).toEqual(contents);
+});
+
+// ── Resposta ─────────────────────────────────────────────────────────────────
+
+it('expõe .text com as partes não-thought, e candidates/usageMetadata intactos', async () => {
+  const sa = await makeTestSa('kid-resp');
+  const apiPayload = {
+    candidates: [
+      {
+        content: { parts: [{ thought: true, text: 'raciocínio' }, { text: 'olá ' }, { text: 'mundo' }] },
+        finishReason: 'STOP',
+      },
+    ],
+    usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2, thoughtsTokenCount: 7 },
+    modelVersion: 'm-001',
+  };
+  const mock = makeFetchMock({ apiPayload });
+  const res = await client(sa, mock).models.generateContent({ model: 'm', contents: 'oi' });
+  expect(res.text).toBe('olá mundo');
+  expect(res.candidates).toEqual(apiPayload.candidates);
+  expect(res.usageMetadata).toEqual(apiPayload.usageMetadata);
+});
+
+it('.text é vazio quando não há candidates ou parts', async () => {
+  const sa = await makeTestSa('kid-resp-vazio');
+  const mock = makeFetchMock({ apiPayload: { candidates: [] } });
+  const res = await client(sa, mock).models.generateContent({ model: 'm', contents: 'oi' });
+  expect(res.text).toBe('');
+});
+
+// ── Cache de token ───────────────────────────────────────────────────────────
+
+it('reusa o access token em chamadas subsequentes dentro da validade', async () => {
+  const sa = await makeTestSa('kid-cache');
+  const mock = makeFetchMock();
+  const ai = client(sa, mock);
+  await ai.models.generateContent({ model: 'm', contents: '1' });
+  await ai.models.generateContent({ model: 'm', contents: '2' });
+  await ai.models.countTokens({ model: 'm', contents: '3' });
+  expect(mock.calls.token).toHaveLength(1);
+  expect(mock.calls.api).toHaveLength(3);
+});
+
+it('reminta o token quando a validade (com margem) expira', async () => {
+  const sa = await makeTestSa('kid-expiry');
+  const mock = makeFetchMock();
+  let nowMs = 1_700_000_000_000;
+  const ai = client(sa, mock, { now: () => nowMs });
+  await ai.models.countTokens({ model: 'm', contents: '1' });
+  nowMs += (3600 - 240) * 1000; // dentro da margem de 300s → precisa remintar
+  await ai.models.countTokens({ model: 'm', contents: '2' });
+  expect(mock.calls.token).toHaveLength(2);
+});
+
+it('single-flight: chamadas concorrentes compartilham uma única mint de token', async () => {
+  const sa = await makeTestSa('kid-flight');
+  let release;
+  const gate = new Promise((r) => {
+    release = r;
+  });
+  const mock = makeFetchMock({ tokenDelay: () => gate });
+  const ai = client(sa, mock);
+  const p1 = ai.models.countTokens({ model: 'm', contents: '1' });
+  const p2 = ai.models.generateContent({ model: 'm', contents: '2' });
+  release();
+  await Promise.all([p1, p2]);
+  expect(mock.calls.token).toHaveLength(1);
+});
+
+it('o cache é por identidade de chave (kid distinto minta separadamente)', async () => {
+  const sa1 = await makeTestSa('kid-iso-1');
+  const sa2 = await makeTestSa('kid-iso-2');
+  const mock = makeFetchMock();
+  await client(sa1, mock).models.countTokens({ model: 'm', contents: 'a' });
+  await client(sa2, mock).models.countTokens({ model: 'm', contents: 'b' });
+  expect(mock.calls.token).toHaveLength(2);
+});
+
+// ── countTokens ──────────────────────────────────────────────────────────────
+
+it('countTokens monta a URL própria e repassa o retorno', async () => {
+  const sa = await makeTestSa('kid-count');
+  const mock = makeFetchMock({ apiPayload: { totalTokens: 42, totalBillableCharacters: 99 } });
+  const res = await client(sa, mock).models.countTokens({ model: 'gemini-3.5-flash', contents: 'conte' });
+  expect(mock.calls.api[0].url).toBe(
+    'https://aiplatform.googleapis.com/v1/projects/proj-x/locations/global/publishers/google/models/gemini-3.5-flash:countTokens',
+  );
+  const body = JSON.parse(mock.calls.api[0].init.body);
+  expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'conte' }] }]);
+  expect(body.generationConfig).toBeUndefined();
+  expect(res.totalTokens).toBe(42);
+});
+
+// ── Erros diagnósticos ───────────────────────────────────────────────────────
+
+it('erro do token endpoint vira Error com status e detalhe do OAuth', async () => {
+  const sa = await makeTestSa('kid-err-token');
+  const mock = makeFetchMock({
+    tokenStatus: 400,
+    tokenPayload: { error: 'invalid_grant', error_description: 'Invalid JWT Signature.' },
+  });
+  await expect(client(sa, mock).models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(
+    /400.*invalid_grant.*Invalid JWT Signature/s,
+  );
+});
+
+it('erro do Vertex vira Error com status e trecho do corpo', async () => {
+  const sa = await makeTestSa('kid-err-api');
+  const mock = makeFetchMock({
+    apiStatus: 429,
+    apiPayload: { error: { code: 429, message: 'Resource exhausted' } },
+  });
+  await expect(client(sa, mock).models.generateContent({ model: 'm', contents: 'x' })).rejects.toThrow(
+    /429.*Resource exhausted/s,
+  );
+});
+
+it('credential JSON sem campo obrigatório falha nomeando o campo', async () => {
+  const sa = await makeTestSa('kid-err-cred');
+  const broken = JSON.stringify({ ...JSON.parse(sa.saJson), private_key: undefined });
+  const mock = makeFetchMock();
+  const ai = new VertexGenAI({ saKeyJson: broken, project: 'p', location: 'global', fetchImpl: mock.fetchImpl });
+  await expect(ai.models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(/private_key/);
+});
+
+it('credential JSON malformado falha com erro diagnóstico, não SyntaxError crua', async () => {
+  const mock = makeFetchMock();
+  const ai = new VertexGenAI({ saKeyJson: 'não-é-json', project: 'p', location: 'global', fetchImpl: mock.fetchImpl });
+  await expect(ai.models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(/VERTEX_SA_KEY.*JSON/s);
+});

--- a/functions/api/_shared/vertex.ts
+++ b/functions/api/_shared/vertex.ts
@@ -1,0 +1,271 @@
+/**
+ * Módulo: calculadora-app/functions/api/_shared/vertex.ts
+ * Versão: v04.03.00
+ * Descrição: Client mínimo do Vertex AI (Gemini Enterprise Agent Platform) para Pages Functions.
+ * Autentica com service account via JWT RS256 (WebCrypto) trocado por access token OAuth2,
+ * com cache por identidade de chave e single-flight para mints concorrentes.
+ * Espelha a superfície de chamada usada do SDK @google/genai (models.generateContent/countTokens)
+ * para manter o diff dos handlers cirúrgico.
+ */
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  private_key_id: string;
+  token_uri: string;
+}
+
+interface VertexGenAIOptions {
+  saKeyJson: string;
+  project: string;
+  location: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+interface GenerateContentConfig {
+  temperature?: number;
+  topP?: number;
+  maxOutputTokens?: number;
+  thinkingConfig?: Record<string, unknown>;
+  safetySettings?: unknown[];
+  systemInstruction?: string | Record<string, unknown>;
+}
+
+interface GenerateContentArgs {
+  model: string;
+  contents: unknown;
+  config?: GenerateContentConfig;
+}
+
+interface CountTokensArgs {
+  model: string;
+  contents: unknown;
+}
+
+interface VertexResponsePart {
+  text?: string;
+  thought?: boolean;
+}
+
+interface VertexCandidate {
+  content?: { parts?: VertexResponsePart[] };
+}
+
+export interface VertexGenerateContentResponse {
+  candidates?: VertexCandidate[];
+  usageMetadata?: Record<string, unknown>;
+  modelVersion?: string;
+  text: string;
+}
+
+const OAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+const OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+const JWT_LIFETIME_S = 3600; // máximo permitido pelo fluxo server-to-server do Google
+const JWT_CLOCK_SKEW_S = 30;
+const TOKEN_SAFETY_MARGIN_S = 300;
+const ERROR_BODY_EXCERPT = 300;
+
+// Cache module-level: sobrevive entre requests no mesmo isolate. Chaveado pela
+// identidade da chave para nunca vazar token entre credenciais distintas.
+const tokenCache = new Map<string, { token: string; expiresAtMs: number }>();
+const inflightMints = new Map<string, Promise<string>>();
+
+function base64UrlFromBytes(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlFromJson(value: unknown): string {
+  return base64UrlFromBytes(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function pemToPkcs8Bytes(pem: string): Uint8Array<ArrayBuffer> {
+  const body = pem.replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '').replace(/\s+/g, '');
+  const binary = atob(body);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function parseServiceAccountKey(saKeyJson: string): ServiceAccountKey {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(saKeyJson);
+  } catch (err) {
+    throw new Error(
+      `VERTEX_SA_KEY inválido: o conteúdo do secret não é JSON parseável (${err instanceof Error ? err.message : 'erro desconhecido'}).`,
+    );
+  }
+  for (const field of ['client_email', 'private_key', 'private_key_id', 'token_uri'] as const) {
+    if (typeof parsed[field] !== 'string' || !parsed[field]) {
+      throw new Error(`VERTEX_SA_KEY inválido: campo obrigatório ausente ou vazio: ${field}`);
+    }
+  }
+  return parsed as unknown as ServiceAccountKey;
+}
+
+async function mintAccessToken(
+  sa: ServiceAccountKey,
+  fetchImpl: typeof fetch,
+  nowMs: number,
+): Promise<{ token: string; expiresInS: number }> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToPkcs8Bytes(sa.private_key),
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const iat = Math.floor(nowMs / 1000) - JWT_CLOCK_SKEW_S;
+  const header = { alg: 'RS256', typ: 'JWT', kid: sa.private_key_id };
+  const claims = {
+    iss: sa.client_email,
+    scope: OAUTH_SCOPE,
+    aud: sa.token_uri,
+    iat,
+    exp: iat + JWT_LIFETIME_S,
+  };
+  const signingInput = `${base64UrlFromJson(header)}.${base64UrlFromJson(claims)}`;
+  const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', cryptoKey, new TextEncoder().encode(signingInput));
+  const assertion = `${signingInput}.${base64UrlFromBytes(new Uint8Array(signature))}`;
+
+  const res = await fetchImpl(sa.token_uri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: OAUTH_GRANT_TYPE, assertion }).toString(),
+  });
+  if (!res.ok) {
+    const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);
+    throw new Error(`Falha ao obter access token OAuth para ${sa.client_email} (HTTP ${res.status}): ${detail}`);
+  }
+  const data = (await res.json()) as { access_token?: string; expires_in?: number };
+  if (!data.access_token) {
+    throw new Error(`Resposta do token endpoint sem access_token (HTTP ${res.status}).`);
+  }
+  return { token: data.access_token, expiresInS: data.expires_in ?? JWT_LIFETIME_S };
+}
+
+async function getAccessToken(sa: ServiceAccountKey, fetchImpl: typeof fetch, now: () => number): Promise<string> {
+  const cacheKey = `${sa.client_email}|${sa.private_key_id}|${sa.token_uri}`;
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAtMs > now()) {
+    return cached.token;
+  }
+  const existing = inflightMints.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+  const mint = (async () => {
+    const { token, expiresInS } = await mintAccessToken(sa, fetchImpl, now());
+    tokenCache.set(cacheKey, {
+      token,
+      expiresAtMs: now() + (expiresInS - TOKEN_SAFETY_MARGIN_S) * 1000,
+    });
+    return token;
+  })();
+  inflightMints.set(cacheKey, mint);
+  try {
+    return await mint;
+  } finally {
+    inflightMints.delete(cacheKey);
+  }
+}
+
+function toContents(contents: unknown): unknown {
+  if (typeof contents === 'string') {
+    return [{ role: 'user', parts: [{ text: contents }] }];
+  }
+  return contents;
+}
+
+function toRestBody(args: GenerateContentArgs): Record<string, unknown> {
+  const body: Record<string, unknown> = { contents: toContents(args.contents) };
+  const config = args.config;
+  if (!config) {
+    return body;
+  }
+  const generationConfig: Record<string, unknown> = {};
+  for (const field of ['temperature', 'topP', 'maxOutputTokens', 'thinkingConfig'] as const) {
+    if (config[field] !== undefined) {
+      generationConfig[field] = config[field];
+    }
+  }
+  if (Object.keys(generationConfig).length > 0) {
+    body.generationConfig = generationConfig;
+  }
+  if (config.systemInstruction !== undefined) {
+    body.systemInstruction =
+      typeof config.systemInstruction === 'string'
+        ? { role: 'user', parts: [{ text: config.systemInstruction }] }
+        : config.systemInstruction;
+  }
+  if (config.safetySettings !== undefined) {
+    body.safetySettings = config.safetySettings;
+  }
+  return body;
+}
+
+function extractText(candidates: VertexCandidate[] | undefined): string {
+  const parts = candidates?.[0]?.content?.parts || [];
+  return parts
+    .filter((p) => typeof p.text === 'string' && !p.thought)
+    .map((p) => p.text)
+    .join('');
+}
+
+export class VertexGenAI {
+  private readonly options: VertexGenAIOptions;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+
+  readonly models = {
+    generateContent: async (args: GenerateContentArgs): Promise<VertexGenerateContentResponse> => {
+      const data = (await this.request(args.model, 'generateContent', toRestBody(args))) as Omit<
+        VertexGenerateContentResponse,
+        'text'
+      >;
+      return { ...data, text: extractText(data.candidates) };
+    },
+    countTokens: async (args: CountTokensArgs): Promise<{ totalTokens?: number }> => {
+      return (await this.request(args.model, 'countTokens', { contents: toContents(args.contents) })) as {
+        totalTokens?: number;
+      };
+    },
+  };
+
+  constructor(options: VertexGenAIOptions) {
+    this.options = options;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.now = options.now ?? Date.now;
+  }
+
+  private baseUrl(): string {
+    const { location } = this.options;
+    return location === 'global'
+      ? 'https://aiplatform.googleapis.com'
+      : `https://${location}-aiplatform.googleapis.com`;
+  }
+
+  private async request(model: string, verb: string, body: Record<string, unknown>): Promise<unknown> {
+    const sa = parseServiceAccountKey(this.options.saKeyJson);
+    const token = await getAccessToken(sa, this.fetchImpl, this.now);
+    const { project, location } = this.options;
+    const url = `${this.baseUrl()}/v1/projects/${project}/locations/${location}/publishers/google/models/${model}:${verb}`;
+    const res = await this.fetchImpl(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);
+      throw new Error(`Vertex ${verb} falhou (HTTP ${res.status}): ${detail}`);
+    }
+    return res.json();
+  }
+}

--- a/functions/api/oraculo.ts
+++ b/functions/api/oraculo.ts
@@ -1,12 +1,12 @@
 /**
  * Módulo: calculadora-app/functions/api/oraculo.ts
- * Versão: v04.00.00
- * Descrição: API do Oráculo IA — refatorada com SDK oficial @google/genai, TypeScript,
- * e sem vazamento de linting `any`.
+ * Versão: v04.03.00
+ * Descrição: API do Oráculo IA — transporte via Vertex AI (Gemini Enterprise Agent Platform)
+ * com autenticação de service account; prompts, fallbacks e telemetria preservados.
  */
 
-import { GoogleGenAI } from '@google/genai';
 import { enforceRateLimit, jsonResponse, requireAllowedOrigin } from './_shared/security.js';
+import { VertexGenAI } from './_shared/vertex.ts';
 
 interface D1DatabaseLike {
   prepare: (query: string) => {
@@ -16,7 +16,9 @@ interface D1DatabaseLike {
 }
 
 interface Env {
-  GEMINI_API_KEY: string;
+  VERTEX_SA_KEY: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
   GEMINI_MODEL?: string;
   BIGDATA_DB?: D1DatabaseLike;
 }
@@ -114,16 +116,18 @@ export async function onRequestPost(context: any) {
     const _telStart = Date.now();
     const promptData = await request.json();
 
-    const { GEMINI_API_KEY } = env;
+    const { VERTEX_SA_KEY } = env;
 
-    if (!GEMINI_API_KEY) {
-      structuredLog('error', 'Missing GEMINI_API_KEY', { endpoint: 'oraculo' });
+    if (!VERTEX_SA_KEY) {
+      structuredLog('error', 'Missing VERTEX_SA_KEY', { endpoint: 'oraculo' });
       return jsonResponse({ erro: 'O administrador ainda não configurou a chave de IA no servidor.' }, 500);
     }
 
     const modelName = env.GEMINI_MODEL || GEMINI_CONFIG.model;
-    const ai = new GoogleGenAI({
-      apiKey: GEMINI_API_KEY,
+    const ai = new VertexGenAI({
+      saKeyJson: VERTEX_SA_KEY,
+      project: env.VERTEX_PROJECT || 'lcv-ideas-and-software',
+      location: env.VERTEX_LOCATION || 'global',
     });
 
     const instrucao = `Analise a simulação de câmbio abaixo e produza exatamente 3 blocos de texto. Cada bloco DEVE começar na primeira linha com o respectivo rótulo seguido de dois-pontos:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "calculadora-app",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calculadora-app",
-      "version": "4.2.4",
+      "version": "4.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@google/genai": "^2.15.0",
         "dompurify": "^3.4.13",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -240,30 +239,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@google/genai": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.15.0.tgz",
-      "integrity": "sha512-Q41TvqwBQ9NcmWdh6qxY5qrpg+0FaVHD7febQoH007pykxzco4ohScBUP4BBBy+Q8j5D8euIBSRIBDfWuNVCKA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -345,63 +320,6 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.1",
@@ -1075,15 +993,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "node_modules/@types/react": {
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
@@ -1103,12 +1012,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -1596,15 +1499,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1614,41 +1508,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1674,37 +1533,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -1801,15 +1634,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.24.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
@@ -1875,12 +1699,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1899,41 +1717,6 @@
         }
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1947,60 +1730,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/graceful-fs": {
@@ -2032,19 +1761,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -2062,36 +1778,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/launder": {
@@ -2364,12 +2050,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2379,12 +2059,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -2404,44 +2078,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2452,19 +2088,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
@@ -2542,29 +2165,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -2584,15 +2184,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/rolldown": {
@@ -2628,26 +2219,6 @@
         "@rolldown/binding-win32-arm64-msvc": "1.2.1",
         "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/sanitize-html": {
       "version": "2.17.6",
@@ -2810,12 +2381,6 @@
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.2.0",
@@ -3258,15 +2823,6 @@
         }
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3282,27 +2838,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calculadora-app",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "description": "Calculadora Financeira — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",
@@ -29,7 +29,6 @@
     "format:public:check": "prettier --check \"**/index.html\""
   },
   "dependencies": {
-    "@google/genai": "^2.15.0",
     "dompurify": "^3.4.13",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
@@ -49,7 +48,6 @@
   },
   "overrides": {
     "picomatch": "4.0.4",
-    "protobufjs": "7.6.5",
     "undici": "6.24.0",
     "vite": "$vite"
   }


### PR DESCRIPTION
## What

Migrates the Oráculo IA endpoint transport from the AI Studio Gemini API (static API key) to **Vertex AI / Gemini Enterprise Agent Platform** (`aiplatform.googleapis.com`) with service-account authentication, keeping prompts, fallback chain, telemetry and the response contract byte-identical.

- **New `functions/api/_shared/vertex.ts`** (271 lines): minimal REST client mirroring the `@google/genai` surface actually used (`models.generateContent` / `models.countTokens`). Auth via WebCrypto RS256 JWT → OAuth2 access token (official server-to-server flow); module-level token cache keyed by credential identity with a 300 s safety margin; single-flight for concurrent mints; global and regional endpoint support; diagnostic errors (HTTP status + body excerpt, field-named credential validation).
- **`functions/api/oraculo.ts`**: surgical swap — import, `Env` interface (`GEMINI_API_KEY` → `VERTEX_SA_KEY`, plus optional `VERTEX_PROJECT`/`VERTEX_LOCATION`) and client construction. Everything else untouched; `GEMINI_MODEL` override contract preserved.
- **Tests**: 17 new client tests (JWT claims with cryptographically verified signature, SDK→REST mapping, cache/expiry/single-flight/per-key isolation, diagnostic error paths) + 3 new handler tests. Suite: **71/71**.
- **Removed**: orphaned `@google/genai` dependency and its `protobufjs` override (kept `undici` override untouched — pre-existing config).
- **Version**: `v04.03.00` (package.json, CHANGELOG, README).

## Why

Google's 2026 billing model assigns new billing accounts to the mandatory **prepaid plan for the Gemini API via AI Studio** — when the credit balance hits zero, every API key on the account stops. Vertex AI usage bills on the standard **postpaid** side of the same billing account (split charging cycle), removing that cliff. The `@google/genai` web build (what runs on Pages Functions) does not support standard-project Vertex auth (constructor throws with `project`/`location`), hence the dedicated REST client.

## Validation

- `vitest run` → 71/71, exit 0 · `biome check` clean · `tsc -b` (strict, functions included) exit 0 · `vite build` OK · `wrangler pages functions build` → "Compiled Worker successfully" (proves the `.ts` import in the real deploy bundler).
- Real Vertex smoke tests with the app's exact `advanced` payload (systemInstruction + `thinkingLevel: 'low'` + 5 safety settings): HTTP 200, `finishReason STOP`, `trafficType ON_DEMAND`; `countTokens` HTTP 200.
- End-to-end validation of the production service-account credential (JWT → OAuth token → Vertex call) with the same WebCrypto primitives as the client, before the secret was stored.
- `VERTEX_SA_KEY` is already configured in the Pages project (production); Pages secrets take effect on the next deployment, i.e. when this PR merges and the Deploy workflow publishes.

## Review

Multi-model cross-review (4 rounds): deepseek, grok and perplexity voted READY; codex raised no code findings across all rounds (evidence-formatting requests only). The gemini peer was unavailable during this window (provider auth outage during a key rotation); shipping with the 4-reviewer panel was explicitly approved by the operator as a documented one-time exception. Internal reasoning gate (ultrabrain) passed with no code defects.

## Rollback

Single-commit revert restores the AI Studio transport (the old `GEMINI_API_KEY` secret remains configured in the Pages project until the decommission phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)