### PR TITLE
fix(vertex): workerd Illegal invocation on detached fetch (v04.03.01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [v04.03.01] - 2026-08-08
+
+**Hotfix — corrige `Illegal invocation` do fetch no runtime de produção do workerd e atualiza as instruções de setup do secret.**
+
+### Corrigido
+
+- O client Vertex invocava o `fetch` global através de `this.fetchImpl`, vazando a instância como `this` — o workerd de produção rejeita com `TypeError: Illegal invocation` (o dev local tolera, por isso só se manifestou pós-deploy). O default agora encapsula o fetch em um wrapper que o invoca desacoplado. Diagnóstico confirmado pelos logs de produção do deployment (7 warns idênticos, countTokens + 3 candidatos × 2 tentativas).
+- README passo 5: instrução de secret atualizada de `GEMINI_API_KEY` para `VERTEX_SA_KEY` (JSON de service account com `roles/aiplatform.user`), documentando os overrides opcionais `VERTEX_PROJECT`/`VERTEX_LOCATION` (finding P2 do bot de review no PR #163).
+
+### Testes
+
+- Novo teste de regressão simula a sensibilidade a `this` do fetch de produção (fake global que lança `Illegal invocation` quando invocado com `this` não-global): RED reproduziu o erro exato de produção, GREEN com o fix. Suíte total: 72/72.
+
 ## [v04.03.00] - 2026-08-08
 
 **Minor — migra o transporte do Oráculo IA do endpoint AI Studio (API key) para o Vertex AI (Gemini Enterprise Agent Platform) com autenticação de service account.**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Calculadora Financeira** — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.
 
-**Status.** Stable. Current release: **v04.03.00**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v04.03.01**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v04.03.01`**                      | **Production hotfix.** Fixes the workerd-only `Illegal invocation` error: the Vertex client invoked global fetch through an instance property, leaking the instance as `this`; the default now wraps fetch detached. Regression test simulates the this-sensitive production fetch (72/72). Also updates README secret setup to VERTEX_SA_KEY (review-bot P2).    |
 | **`v04.03.00`**                      | **Vertex AI transport migration.** Oráculo IA now calls Vertex AI with service-account auth (WebCrypto RS256 JWT -> OAuth2, per-key token cache, single-flight), moving Gemini billing from AI Studio prepaid credits to standard postpaid Cloud billing; prompts, fallback chain, telemetry and the GEMINI_MODEL override unchanged.                             |
 | **`v04.02.04`**                      | **Backtest threshold precedence fix.** Custom MAPE thresholds now follow D1 > finite payload > valid environment > default, preserving percentage-point scale; focused tests cover every tier and prove that a PTAX cache hit performs no external request. |
 | **`v04.02.03`**                      | **Dependency security patch.** Resolves GHSA-j3f2-48v5-ccww / CVE-2026-59877 by moving the transitive `protobufjs` override used by `@google/genai` from 7.6.3 to 7.6.5. |
@@ -122,7 +123,7 @@ The Pages Functions self-bootstrap their tables via `CREATE TABLE IF NOT EXISTS`
 
 ### 5. Configure secrets (optional, only if using Gemini analysis)
 
-Set `GEMINI_API_KEY` as a Cloudflare Pages secret via the dashboard or `wrangler secret put GEMINI_API_KEY --env production`.
+Set `VERTEX_SA_KEY` as a Cloudflare Pages secret — the full JSON key of a GCP service account with the `roles/aiplatform.user` role — via the dashboard or `wrangler pages secret put VERTEX_SA_KEY --project-name <project>`. The Oráculo endpoint calls Vertex AI (Gemini Enterprise Agent Platform); optional plain-text vars `VERTEX_PROJECT` and `VERTEX_LOCATION` override the default GCP project and location (`global`).
 
 ### 6. Build + deploy
 

--- a/functions/api/__tests__/vertex-client.test.mjs
+++ b/functions/api/__tests__/vertex-client.test.mjs
@@ -277,6 +277,34 @@ it('countTokens monta a URL própria e repassa o retorno', async () => {
   expect(res.totalTokens).toBe(42);
 });
 
+// ── Fetch global (regressão de produção) ─────────────────────────────────────
+
+it('invoca o fetch global desacoplado do this da instância (regressão: Illegal invocation no workerd)', async () => {
+  const sa = await makeTestSa('kid-global-fetch');
+  const urls = [];
+  const originalFetch = globalThis.fetch;
+  // O fetch do workerd de produção lança TypeError quando invocado com um
+  // `this` que não é o escopo global — simulamos essa sensibilidade aqui.
+  globalThis.fetch = function (url, _init) {
+    if (this !== undefined && this !== globalThis) {
+      throw new TypeError('Illegal invocation: function called with incorrect `this` reference.');
+    }
+    urls.push(String(url));
+    if (String(url).includes('oauth2.test.invalid')) {
+      return Promise.resolve(jsonResponse(200, { access_token: 'tok-g', expires_in: 3600 }));
+    }
+    return Promise.resolve(jsonResponse(200, { totalTokens: 1 }));
+  };
+  try {
+    const ai = new VertexGenAI({ saKeyJson: sa.saJson, project: 'proj-x', location: 'global' });
+    const res = await ai.models.countTokens({ model: 'm', contents: 'x' });
+    expect(res.totalTokens).toBe(1);
+    expect(urls).toHaveLength(2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 // ── Erros diagnósticos ───────────────────────────────────────────────────────
 
 it('erro do token endpoint vira Error com status e detalhe do OAuth', async () => {

--- a/functions/api/_shared/vertex.ts
+++ b/functions/api/_shared/vertex.ts
@@ -1,6 +1,6 @@
 /**
  * Módulo: calculadora-app/functions/api/_shared/vertex.ts
- * Versão: v04.03.00
+ * Versão: v04.03.01
  * Descrição: Client mínimo do Vertex AI (Gemini Enterprise Agent Platform) para Pages Functions.
  * Autentica com service account via JWT RS256 (WebCrypto) trocado por access token OAuth2,
  * com cache por identidade de chave e single-flight para mints concorrentes.
@@ -241,7 +241,9 @@ export class VertexGenAI {
 
   constructor(options: VertexGenAIOptions) {
     this.options = options;
-    this.fetchImpl = options.fetchImpl ?? fetch;
+    // O fetch global do workerd exige `this` global; chamar via this.fetchImpl
+    // vazaria a instância como `this` e lança Illegal invocation em produção.
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => fetch(input, init));
     this.now = options.now ?? Date.now;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calculadora-app",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calculadora-app",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calculadora-app",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Calculadora Financeira — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",


### PR DESCRIPTION
## What

Production hotfix for the Vertex transport shipped in #163. `/api/oraculo` returned 500 in production because the Vertex client invoked the global `fetch` through an instance property (`this.fetchImpl(...)`), leaking the instance as `this` — production workerd rejects this with `TypeError: Illegal invocation: function called with incorrect 'this' reference` (confirmed via deployment tail logs: identical warnings on countTokens and on every fallback candidate attempt). Node test runs and local `wrangler dev` tolerate the call, which is why the suite and a local minimal-worker repro stayed green.

- **Fix (2 lines)**: the default now wraps fetch so it is always invoked detached: `options.fetchImpl ?? ((input, init) => fetch(input, init))`.
- **Regression test**: installs a this-sensitive `globalThis.fetch` fake (throws `Illegal invocation` when invoked with a non-global `this`, mirroring production workerd), constructs the client without `fetchImpl` and exercises the token + API call path. It reproduced the exact production error before the fix. Suite: **72/72**.
- **Docs (review-bot P2 from #163)**: README step 5 now documents `VERTEX_SA_KEY` (service-account JSON with `roles/aiplatform.user`) and the optional `VERTEX_PROJECT`/`VERTEX_LOCATION` overrides instead of the obsolete `GEMINI_API_KEY` instruction.
- **Version**: `v04.03.01` (package.json, CHANGELOG, README).

## Validation

`vitest` 72/72 · `biome` clean · strict `tsc -b` exit 0 · `vite build` OK · `wrangler pages functions build` OK. Root cause evidenced by production deployment logs; regression test derived directly from them (RED before fix, GREEN after).

## Review

Multi-model cross-review: codex, deepseek and grok voted READY (formal), perplexity READY (raw). The gemini peer remains unavailable during this window (same documented operator-approved exception as #163).

## Rollback

Single-commit revert (restores the broken transport, so not recommended; #163's rollback path remains available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)