### PR TITLE
ci: adopt strict CodeQL SARIF gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,36 +54,6 @@ jobs:
           output: ${{ runner.temp }}/codeql-results
 
       - name: Enforce zero CodeQL findings
-        shell: bash
-        env:
-          CODEQL_RESULTS: ${{ runner.temp }}/codeql-results
-        run: |
-          set -euo pipefail
-          mapfile -d '' sarif_files < <(
-            find "$CODEQL_RESULTS" -type f -name '*.sarif' -print0
-          )
-          if [ "${#sarif_files[@]}" -eq 0 ]; then
-            echo "::error::CodeQL produced no SARIF file to enforce." >&2
-            exit 1
-          fi
-          finding_count="$(
-            jq -s '[.[].runs[]?.results[]?] | length' "${sarif_files[@]}"
-          )"
-          if [ "$finding_count" -ne 0 ]; then
-            finding_inventory="$(
-              jq -cs '
-                [
-                  .[].runs[]?.results[]?
-                  | {
-                      ruleId: (.ruleId // "unknown"),
-                      level: (.level // "unknown"),
-                      path: (.locations[0]?.physicalLocation?.artifactLocation?.uri // "unknown"),
-                      line: (.locations[0]?.physicalLocation?.region?.startLine // null)
-                    }
-                ]
-              ' "${sarif_files[@]}"
-            )"
-            echo "::error::CodeQL reported $finding_count SARIF result(s); zero are allowed. Inventory: $finding_inventory" >&2
-            exit 1
-          fi
-          echo "CodeQL reported zero SARIF results."
+        uses: LCV-Ideas-Software/.github/codeql-sarif-gate@24b0bcc09a48b47f740b8a8bd972374f7289e48e # codeql-sarif-v1.0.0
+        with:
+          sarif-directory: ${{ runner.temp }}/codeql-results


### PR DESCRIPTION
## What changed

- replace the permissive inline `find`/`jq` SARIF aggregation with the organization-owned strict CodeQL SARIF gate
- pin the composite Action to immutable commit `24b0bcc09a48b47f740b8a8bd972374f7289e48e` (`codeql-sarif-v1.0.0`)
- preserve the existing CodeQL triggers, matrix, permissions, output directory, and required context

## Why

The shared gate validates every SARIF document independently, requires complete direct CodeQL result structure and validates successful invocations/notifications when emitted, and fails closed on malformed, incomplete, externalized, or non-empty results.

## Validation

- `actionlint` (with only the pre-existing `concurrency.queue` schema false-positive ignored where present)
- authenticated `zizmor --pedantic --strict-collection`
- `prettier --check .github/workflows/codeql.yml`
- `git diff --check`
- exact one-file semantic diff and immutable Action provenance/signature verification

No application code, ruleset, environment, secret, or permission changed.