### PR TITLE
fix(release): realinha os marcadores de release — v04.03.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [v04.03.02] - 2026-08-10
+
+### Corrigido
+
+- **`APP_VERSION` e `SECURITY.md` estavam dois lançamentos atrás, e isso engoliu
+  duas releases.** O `auto-release.yml` deriva a tag de `APP_VERSION` em
+  `src/services/formatting.ts` (`VERSION_FILE`); como a constante ficou em
+  `v04.02.04`, a v04.03.00 (migração Vertex) e a v04.03.01 (hotfix do
+  `Illegal invocation`) foram publicadas **sem tag e sem release** — a última
+  release do repositório era a v04.02.04, de 03/08 — e a interface mostrava
+  `APP v04.02.04` rodando código v04.03.01. As quatro superfícies voltam a
+  concordar; esta é a primeira release marcada que contém o transporte Vertex.
+
+### Testes
+
+- Novo `src/services/releaseConsistency.test.ts`: deriva o marcador de release do
+  `package.json` e trava `APP_VERSION`, o alvo do `README.md` e o do
+  `SECURITY.md` no mesmo valor. É o guard que faltava para o drift não voltar a
+  passar em silêncio — o `astrologo-app` já tinha o equivalente.
+
 ## [v04.03.01] - 2026-08-08
 
 **Hotfix — corrige `Illegal invocation` do fetch no runtime de produção do workerd e atualiza as instruções de setup do secret.**

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Calculadora Financeira** — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.
 
-**Status.** Stable. Current release: **v04.03.01**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v04.03.02**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v04.03.02`**                      | **Release markers realigned — two releases had shipped untagged.** `auto-release.yml` derives the tag from `APP_VERSION` in `src/services/formatting.ts`, which had stayed at `v04.02.04`, so v04.03.00 and v04.03.01 produced no tag and no release while the UI reported the wrong version. A new `releaseConsistency` test derives the marker from `package.json` and locks `APP_VERSION`, README and SECURITY together so the drift cannot recur silently. |
 | **`v04.03.01`**                      | **Production hotfix.** Fixes the workerd-only `Illegal invocation` error: the Vertex client invoked global fetch through an instance property, leaking the instance as `this`; the default now wraps fetch detached. Regression test simulates the this-sensitive production fetch (72/72). Also updates README secret setup to VERTEX_SA_KEY (review-bot P2).    |
 | **`v04.03.00`**                      | **Vertex AI transport migration.** Oráculo IA now calls Vertex AI with service-account auth (WebCrypto RS256 JWT -> OAuth2, per-key token cache, single-flight), moving Gemini billing from AI Studio prepaid credits to standard postpaid Cloud billing; prompts, fallback chain, telemetry and the GEMINI_MODEL override unchanged.                             |
 | **`v04.02.04`**                      | **Backtest threshold precedence fix.** Custom MAPE thresholds now follow D1 > finite payload > valid environment > default, preserving percentage-point scale; focused tests cover every tier and prove that a PTAX cache hit performs no external request. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v04.02.04. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v04.03.02. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/functions/api/__tests__/releaseConsistency.test.mjs
+++ b/functions/api/__tests__/releaseConsistency.test.mjs
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+const readProjectFile = (relativePath) => readFile(new URL(relativePath, import.meta.url), 'utf8');
+
+const releaseMarkerFromPackageVersion = (version) => {
+  const segments = version.split('.');
+  if (segments.length !== 3 || segments.some((segment) => !/^\d+$/u.test(segment))) {
+    throw new TypeError(`Invalid package version: ${version}`);
+  }
+  return `v${segments.map((segment) => segment.padStart(2, '0')).join('.')}`;
+};
+
+describe('release marker consistency', () => {
+  // O auto-release deriva a tag de APP_VERSION em src/services/formatting.ts
+  // (VERSION_FILE no workflow). Quando essa constante fica para trás, a release
+  // some: v04.03.00 e v04.03.01 foram publicadas sem tag porque APP_VERSION
+  // continuava em v04.02.04. Este guard trava as quatro superfícies juntas.
+  it('mantém APP_VERSION, README e SECURITY alinhados com package.json', async () => {
+    const [packageText, readme, securityPolicy, appVersionSource] = await Promise.all([
+      readProjectFile('../../../package.json'),
+      readProjectFile('../../../README.md'),
+      readProjectFile('../../../SECURITY.md'),
+      readProjectFile('../../../src/services/formatting.ts'),
+    ]);
+    const packageVersion = JSON.parse(packageText).version;
+    const releaseMarker = releaseMarkerFromPackageVersion(packageVersion);
+
+    expect(appVersionSource).toContain(`const APP_VERSION = 'APP ${releaseMarker}';`);
+    expect(readme).toContain(`Current release: **${releaseMarker}**`);
+    expect(securityPolicy).toContain(`Latest supported release: ${releaseMarker}.`);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calculadora-app",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calculadora-app",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calculadora-app",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Calculadora Financeira — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/src/services/formatting.ts
+++ b/src/services/formatting.ts
@@ -7,7 +7,7 @@
    Funções de formatação numérica e moeda
    ==================================================================== */
 
-const APP_VERSION = 'APP v04.02.04';
+const APP_VERSION = 'APP v04.03.02';
 
 export { APP_VERSION };
 


### PR DESCRIPTION
Duas releases deste repositório foram publicadas sem tag e sem release, e ninguém percebeu porque não havia nada checando.

## O que aconteceu

O `auto-release.yml` deriva a tag do `APP_VERSION`:

```
.github/workflows/auto-release.yml:29
  VERSION_FILE: src/services/formatting.ts
```

Essa constante ficou em `v04.02.04` enquanto as outras superfícies avançaram:

| Superfície | Antes deste PR |
| --- | --- |
| `package.json` | 4.3.1 |
| `CHANGELOG.md` | `[v04.03.01]`, `[v04.03.00]` — ambos de 08/08 |
| `README.md` | v04.03.01 |
| **`src/services/formatting.ts:10`** | **`APP v04.02.04`** |
| **`SECURITY.md:5`** | **v04.02.04** |

Consequências reais, não cosméticas:

```
$ gh release list --repo LCV-Ideas-Software/calculadora-app --limit 3
v04.02.04   Latest   v04.02.04   2026-08-03T22:31:23Z
v04.02.03            v04.02.03   2026-07-21T10:07:36Z
v04.02.02            v04.02.02   2026-07-12T20:09:24Z
```

A v04.03.00 (migração para o Vertex) e a v04.03.01 (hotfix do `Illegal invocation` no workerd) nunca ganharam tag — a última release do repositório é de 03/08, anterior às duas. E a interface exibia `APP v04.02.04` rodando código v04.03.01.

## A correção

As quatro superfícies voltam a concordar, em **v04.03.02**. Patch próprio em vez de reescrever a v04.03.01 já publicada; esta passa a ser a primeira release marcada que contém o transporte Vertex.

## O guard que faltava

A causa de o drift passar em silêncio é que nada amarrava as superfícies. O `astrologo-app` já tinha o equivalente (`astrologo-frontend/functions/api/_shared/releaseConsistency.test.ts`); aqui não havia.

`functions/api/__tests__/releaseConsistency.test.mjs` deriva o marcador do `package.json` e trava `APP_VERSION`, o alvo do `README.md` e o do `SECURITY.md` no mesmo valor.

Nasceu **RED contra o drift real**, antes de qualquer correção:

```
AssertionError: expected '/* ... */' to contain 'const APP_VERSION = 'APP v04.03.01';'
 ❯ src/services/releaseConsistency.test.ts:34:30
```

E confirmei por mutação que continua com dentes: voltando `APP_VERSION` para `v04.02.04` com tudo o mais alinhado, o teste falha.

Ele fica em `.mjs` sob `functions/` porque o `tsconfig.app.json` compila `src` com `"types": ["vite/client"]` e sem os tipos de node — a primeira versão, em `src/services/*.test.ts`, quebrava o build com `TS2591: Cannot find name 'node:fs/promises'`. Os demais testes de Node deste repo vivem lá pelo mesmo motivo.

## Verificação

`test` (**73/73 em 12 arquivos**), `lint`, `biome`, `build`, `format:public:check` e `git diff --check` — exit 0, conferidos pelo código de saída real do comando.

## Efeito esperado no merge

Com `APP_VERSION` em `v04.03.02`, o `auto-release` deve criar a tag `v04.03.02` e a release correspondente. A v04.03.00 e a v04.03.01 seguem sem tag própria — o conteúdo das duas está contido nesta, e o CHANGELOG registra o porquê.

## Auto-merge

Não armado. Fica aberto para o Copilot e o codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
