### PR TITLE
docs(changelog): corrige o caminho do guard nas notas da v04.03.02 — v04.03.03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [v04.03.03] - 2026-08-10
+
+### Corrigido
+
+- **A entrada da v04.03.02 apontava o guard para o caminho errado.** O texto
+  citava `src/services/releaseConsistency.test.ts`, que foi a primeira
+  tentativa; o teste acabou em `functions/api/__tests__/` porque o
+  `tsconfig.app.json` compila `src` sem os tipos de node e a versão `.ts`
+  quebrava o build com `TS2591`. Notas de release que apontam para um arquivo
+  inexistente valem menos que nenhuma nota, então o caminho foi corrigido na
+  entrada da v04.03.02 — e esta entrada registra a correção, para que a
+  alteração de um texto já publicado não fique silenciosa. Achado do Copilot no
+  PR #170.
+
 ## [v04.03.02] - 2026-08-10
 
 ### Corrigido
@@ -17,10 +31,11 @@
 
 ### Testes
 
-- Novo `src/services/releaseConsistency.test.ts`: deriva o marcador de release do
-  `package.json` e trava `APP_VERSION`, o alvo do `README.md` e o do
+- Novo `functions/api/__tests__/releaseConsistency.test.mjs`: deriva o marcador de
+  release do `package.json` e trava `APP_VERSION`, o alvo do `README.md` e o do
   `SECURITY.md` no mesmo valor. É o guard que faltava para o drift não voltar a
-  passar em silêncio — o `astrologo-app` já tinha o equivalente.
+  passar em silêncio — o `astrologo-app` já tinha o equivalente. (Caminho
+  corrigido na v04.03.03; esta entrada citava a primeira tentativa em `src/`.)
 
 ## [v04.03.01] - 2026-08-08
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 **Calculadora Financeira** — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.
 
-**Status.** Stable. Current release: **v04.03.02**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release: **v04.03.03**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release                              | Scope                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v04.03.03`**                      | **Corrects the guard path recorded in the v04.03.02 notes.** Those notes named `src/services/releaseConsistency.test.ts`, the first attempt; the test lives in `functions/api/__tests__/` because `tsconfig.app.json` compiles `src` without node types. The path is fixed in the v04.03.02 entry and the change is recorded here rather than made silently. |
 | **`v04.03.02`**                      | **Release markers realigned — two releases had shipped untagged.** `auto-release.yml` derives the tag from `APP_VERSION` in `src/services/formatting.ts`, which had stayed at `v04.02.04`, so v04.03.00 and v04.03.01 produced no tag and no release while the UI reported the wrong version. A new `releaseConsistency` test derives the marker from `package.json` and locks `APP_VERSION`, README and SECURITY together so the drift cannot recur silently. |
 | **`v04.03.01`**                      | **Production hotfix.** Fixes the workerd-only `Illegal invocation` error: the Vertex client invoked global fetch through an instance property, leaking the instance as `this`; the default now wraps fetch detached. Regression test simulates the this-sensitive production fetch (72/72). Also updates README secret setup to VERTEX_SA_KEY (review-bot P2).    |
 | **`v04.03.00`**                      | **Vertex AI transport migration.** Oráculo IA now calls Vertex AI with service-account auth (WebCrypto RS256 JWT -> OAuth2, per-key token cache, single-flight), moving Gemini billing from AI Studio prepaid credits to standard postpaid Cloud billing; prompts, fallback chain, telemetry and the GEMINI_MODEL override unchanged.                             |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported release: v04.03.02. The current main branch is also supported for security fixes until the next release is published.
+Latest supported release: v04.03.03. The current main branch is also supported for security fixes until the next release is published.
 
 ## Reporting a vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calculadora-app",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calculadora-app",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calculadora-app",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Calculadora Financeira — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.",
   "license": "AGPL-3.0-or-later",
   "author": "LCV Ideas & Software",

--- a/src/services/formatting.ts
+++ b/src/services/formatting.ts
@@ -7,7 +7,7 @@
    Funções de formatação numérica e moeda
    ==================================================================== */
 
-const APP_VERSION = 'APP v04.03.02';
+const APP_VERSION = 'APP v04.03.03';
 
 export { APP_VERSION };
 


### PR DESCRIPTION
Follow-up do achado do Copilot em #170, que mergeou antes da correção chegar.

## O erro

As notas da v04.03.02 apontavam o guard para `src/services/releaseConsistency.test.ts`. Esse foi o caminho da primeira tentativa: o teste acabou em `functions/api/__tests__/releaseConsistency.test.mjs` porque o `tsconfig.app.json` compila `src` com `"types": ["vite/client"]` e sem os tipos de node — a versão `.ts` quebrava o build com `TS2591: Cannot find name 'node:fs/promises'`.

Notas de release que apontam para um arquivo inexistente valem menos que nenhuma nota.

## A correção

O caminho foi corrigido **na entrada da v04.03.02**, porque deixá-lo errado tornaria aquelas notas permanentemente enganosas. Para que a alteração de um texto já publicado não fique silenciosa, a entrada da v04.03.03 registra o que mudou e por quê, e a própria entrada da v04.03.02 ganhou a marca `(Caminho corrigido na v04.03.03)`.

## Efeito colateral bom do PR anterior

O guard que a v04.03.02 introduziu já está trabalhando: como `package.json` subiu para 4.3.3, ele obrigou `APP_VERSION`, `README.md` e `SECURITY.md` a subirem juntos. Era exatamente esse acoplamento que faltava quando a v04.03.00 e a v04.03.01 saíram sem tag.

**A v04.03.02 gerou tag e release** às 11:57 — `gh release list` agora mostra `v04.03.02  Latest`, contra `v04.02.04` de 03/08 antes do PR. O defeito original está fechado.

## Verificação

`test` (**73/73 em 12 arquivos**), `lint`, `biome`, `build`, `format:public:check` e `git diff --check` — exit 0, pelo código de saída real. As duas ocorrências restantes do caminho antigo são as menções que explicam a correção.

## Auto-merge

Não armado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)