### PR TITLE
feat: track all work in GitHub Projects, Issues and Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,9 @@ contact_links:
   - name: Private security report
     url: https://github.com/LCV-Ideas-Software
     about: Report vulnerabilities privately. Do not disclose secrets or exploit details in public issues.
+  - name: Ask a question (Discussions)
+    url: https://github.com/LCV-Ideas-Software/calculadora-app/discussions/new?category=q-a
+    about: Technical questions about this repository. Answers are marked and become the durable record.
+  - name: Propose an idea (Discussions)
+    url: https://github.com/LCV-Ideas-Software/calculadora-app/discussions/new?category=ideas
+    about: New apps, features or directions. Ideas that mature become issues.

--- a/.github/ISSUE_TEMPLATE/incident.yml
+++ b/.github/ISSUE_TEMPLATE/incident.yml
@@ -1,0 +1,57 @@
+name: Incident
+description: Production is broken or degraded and needs a root cause
+title: "[Incident]: "
+labels: ["bug"]
+type: Incident
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use placeholders instead of real infrastructure identifiers. This repository is public.
+        Never paste cloud project IDs, database names, tokens, or account identifiers.
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What is broken, for whom, and since when?
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options: [Production, Preview, Local, CI]
+    validations:
+      required: true
+  - type: textarea
+    id: timeline
+    attributes:
+      label: Timeline
+      description: What happened, in order, with timestamps in UTC.
+      value: |
+        - HH:MM —
+        - HH:MM —
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, failing check URLs, error output. Redact secrets and real identifiers.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Mitigation applied
+      description: What restored service, if anything. Write "none yet" if still broken.
+    validations:
+      required: true
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: Root cause hypothesis
+      description: What you believe caused it and what evidence supports that.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,33 @@
+name: Maintenance
+description: Dependency bumps, lockfiles, version bumps and routine upkeep
+title: "[Maintenance]: "
+labels: ["dependencies"]
+type: Maintenance
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs upkeep
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now
+      description: Advisory, deprecation, drift, or scheduled upkeep.
+    validations:
+      required: true
+  - type: textarea
+    id: surfaces
+    attributes:
+      label: Surfaces touched
+      description: Every file or configuration that must change together.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: How it will be verified
+      description: Which gates must pass before this is considered done.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,33 @@
+name: Spike
+description: Time-boxed investigation with no guaranteed deliverable
+title: "[Spike]: "
+type: Spike
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question to answer
+      description: A single, decidable question. Not "look into X".
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it matters
+      description: What decision is blocked until this is answered.
+    validations:
+      required: true
+  - type: input
+    id: timebox
+    attributes:
+      label: Time box
+      placeholder: "e.g. 2 hours"
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      description: What artifact ends this spike — a written answer, a benchmark, a prototype?
+    validations:
+      required: true

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,62 @@
+name: Add to project
+
+# Coloca toda issue e todo pull request nos quadros do repositorio e do portfolio.
+# Inerte enquanto a variavel LCV_PROJECTS_APP_CLIENT_ID nao estiver definida na organizacao.
+#
+# Pre-requisito (acao do operador): GitHub App da organizacao com permissao de leitura e
+# escrita em **projects de organizacao** (permissao de projects de repositorio nao basta),
+# instalado neste repositorio, com:
+#   - variavel de organizacao LCV_PROJECTS_APP_CLIENT_ID
+#   - secret LCV_PROJECTS_APP_PRIVATE_KEY no environment 'projects-automation' deste repo
+# GITHUB_TOKEN nao acessa Projects v2, por isso o App e obrigatorio.
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: add-to-project-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  add:
+    name: Add item to projects
+    if: ${{ vars.LCV_PROJECTS_APP_CLIENT_ID != '' }}
+    runs-on: ubuntu-latest
+    permissions: write-all
+    # Confina a chave privada do App a este job (zizmor secrets-outside-env).
+    # Mesmo padrao ja usado pela organizacao para credenciais de automacao.
+    environment: projects-automation
+    steps:
+      - name: Mint installation token
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        env:
+          # zizmor secrets-outside-env: segredo so pode ser referenciado via env
+          APP_PRIVATE_KEY: ${{ secrets.LCV_PROJECTS_APP_PRIVATE_KEY }}
+        with:
+          client-id: ${{ vars.LCV_PROJECTS_APP_CLIENT_ID }}
+          private-key: ${{ env.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # zizmor github-app: token restrito a este repositorio e as permissoes minimas
+          repositories: ${{ github.event.repository.name }}
+          permission-organization-projects: write
+          permission-issues: read
+          permission-pull-requests: read
+
+      - name: Add to repository project
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          project-url: https://github.com/orgs/LCV-Ideas-Software/projects/9
+          github-token: ${{ steps.token.outputs.token }}
+
+      - name: Add to portfolio project
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          project-url: https://github.com/orgs/LCV-Ideas-Software/projects/17
+          github-token: ${{ steps.token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Governanca de trabalho sobre GitHub Projects, Issues e Discussions: quadro dedicado do
+  repositorio, formularios de issue para Incident, Maintenance e Spike, atalhos para
+  Discussions no seletor de issues, workflow `add-to-project` (inerte ate a organizacao
+  definir `LCV_PROJECTS_APP_CLIENT_ID`) e o ritual de registro G1..G4 documentado para
+  Claude Code e ChatGPT-Codex.
+
+
+## [Unreleased]
+
 ## [v04.03.03] - 2026-08-10
 
 ### Corrigido


### PR DESCRIPTION
## Summary

Liga este repositorio ao sistema de rastreamento de trabalho da organizacao.

- Quadro do repositorio: https://github.com/orgs/LCV-Ideas-Software/projects/9
- Quadro consolidado: https://github.com/orgs/LCV-Ideas-Software/projects/17

## What changed

- `.github/workflows/add-to-project.yml` — coloca issues e PRs nos dois quadros.
  **Inerte** enquanto `vars.LCV_PROJECTS_APP_CLIENT_ID` nao existir: o job nem inicia.
  Usa `pull_request` (nao `pull_request_target`) para nao acionar a auditoria
  `dangerous-triggers` do zizmor.
- `.github/ISSUE_TEMPLATE/{incident,maintenance,spike}.yml` — formularios para os tipos de
  issue novos da organizacao. Os templates existentes **nao foram tocados**.
- `.github/ISSUE_TEMPLATE/config.yml` — acrescenta atalhos para Discussions. Conteudo
  anterior preservado.
- `AGENTS.md` / `CLAUDE.md` — ritual de registro G1..G4, para que Claude e Codex saibam
  o que registrar e onde.
- `CHANGELOG.md` — entrada em `[Unreleased]`.

## Version

Sem bump de versao: a mudanca e de governanca, sob `.github/` e documentacao de agente,
e nao altera comportamento do produto. Decisao do operador.

## Operator action required

O workflow so sai da inercia quando existirem:
- variavel de **organizacao** `LCV_PROJECTS_APP_CLIENT_ID`
- secret `LCV_PROJECTS_APP_PRIVATE_KEY` no environment **`projects-automation`** deste repositorio

de um GitHub App com permissao de leitura e escrita em **projects de organizacao**
(permissao de projects de repositorio nao basta) instalado neste repositorio.
`GITHUB_TOKEN` nao acessa Projects v2.

O job declara `environment: projects-automation` para confinar a chave privada do App a
esse unico job — mesmo padrao que a organizacao ja usa para credenciais de automacao, e
exigencia da auditoria `secrets-outside-env` do zizmor.
