### PR TITLE
chore(ci): preflight P1 fix for #188 [do not merge]

### DIFF
--- a/.github/scripts/native-auto-merge-workflows.regression.mjs
+++ b/.github/scripts/native-auto-merge-workflows.regression.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// Keep this outside Vitest's *.test.* discovery; CI invokes Node's runner directly.
+
+const NATIVE_REF =
+  "LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4";
+const ZIZMOR_REF =
+  "LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # zizmor/v2.0.0";
+const CODEQL_SARIF_REF =
+  "LCV-Ideas-Software/.github/codeql-sarif-gate@24b0bcc09a48b47f740b8a8bd972374f7289e48e # codeql-sarif-gate/v1.0.0";
+
+const [native, dependencyReview, zizmorConfig, zizmorWorkflow, codeqlWorkflow] =
+  await Promise.all([
+    readFile(
+      new URL("../workflows/native-auto-merge.yml", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../workflows/dependency-review.yml", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../zizmor.yml", import.meta.url), "utf8"),
+    readFile(new URL("../workflows/zizmor.yml", import.meta.url), "utf8"),
+    readFile(new URL("../workflows/codeql.yml", import.meta.url), "utf8"),
+  ]);
+
+function topLevelBody(workflow, key) {
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.indexOf(`${key}:`);
+  assert.notEqual(start, -1, `${key} must be present`);
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex((line) => /^[A-Za-z0-9_-]+:/.test(line));
+  const end = relativeEnd === -1 ? lines.length : start + 1 + relativeEnd;
+  return lines.slice(start + 1, end).join("\n");
+}
+
+function jobBody(workflow, jobName) {
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.indexOf(`  ${jobName}:`);
+  assert.notEqual(start, -1, `${jobName} job must be present`);
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex((line) => /^  [A-Za-z0-9_-]+:\s*$/.test(line));
+  const end = relativeEnd === -1 ? lines.length : start + 1 + relativeEnd;
+  return lines.slice(start + 1, end).join("\n");
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function assertExactExpression(body, input, expression) {
+  assert.match(
+    body,
+    new RegExp(
+      `\\n\\s+${escapeRegex(input)}: \\$\\{\\{ ${escapeRegex(expression)} \\}\\}`,
+    ),
+    `${input} must bind exactly to ${expression}`,
+  );
+}
+
+test("the trusted controller exposes both pinned v2.1.4 wake-up paths", () => {
+  const events = topLevelBody(native, "on");
+  const enable = jobBody(native, "enable");
+
+  assert.match(events, /workflow_run:[\s\S]*workflows:[\s\S]*- CodeQL/);
+  assert.match(events, /pull_request_target:[\s\S]*- review_requested/);
+  assert.match(
+    topLevelBody(native, "concurrency"),
+    /github\.event\.workflow_run\.id \|\| github\.run_id/,
+  );
+  assert.match(enable, /timeout-minutes: 30/);
+  assert.equal(
+    (
+      native.match(
+        new RegExp(NATIVE_REF.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+      ) ?? []
+    ).length,
+    2,
+  );
+  assert.match(enable, /github\.event\.requested_reviewer\.id == 175728472/);
+  assert.match(
+    enable,
+    /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  );
+
+  for (const [input, expression] of Object.entries({
+    workflow_name: "github.event.workflow_run.name",
+    workflow_path: "github.event.workflow_run.path",
+    workflow_display_title: "github.event.workflow_run.display_title",
+    workflow_status: "github.event.workflow_run.status",
+    workflow_event: "github.event.workflow_run.event",
+    workflow_head_sha: "github.event.workflow_run.head_sha",
+    workflow_actor_id: "github.event.workflow_run.actor.id",
+    workflow_pull_requests: "toJSON(github.event.workflow_run.pull_requests)",
+    event_action: "github.event.action",
+    pull_number: "github.event.pull_request.number",
+    pull_head_sha: "github.event.pull_request.head.sha",
+    pull_head_repository: "github.event.pull_request.head.repo.full_name",
+    pull_base_ref: "github.event.pull_request.base.ref",
+    requested_reviewer_id: "github.event.requested_reviewer.id",
+    trigger_run_id: "github.run_id",
+  })) {
+    assertExactExpression(enable, input, expression);
+  }
+
+  assert.doesNotMatch(
+    native,
+    /actions\/checkout|download-artifact|actions\/cache|github_token:|continue-on-error:|uses:\s*\.\/|merge-group-feedback-gate/,
+  );
+});
+
+test("the existing Dependency Review context becomes the clean merge-group gate", () => {
+  const candidate = jobBody(dependencyReview, "candidate_review");
+  const required = jobBody(dependencyReview, "dependency_review");
+
+  assert.match(
+    topLevelBody(dependencyReview, "on"),
+    /merge_group:[\s\S]*checks_requested/,
+  );
+  assert.match(candidate, /name: Dependency Review candidate/);
+  assert.match(
+    candidate,
+    /actions\/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294/,
+  );
+  assert.match(
+    candidate,
+    /node --test \.github\/scripts\/native-auto-merge-workflows\.regression\.mjs/,
+  );
+  assert.match(required, /^ {4}name: Dependency Review$/m);
+  assert.match(required, /always\(\)/);
+  assert.match(
+    required,
+    /github\.event_name == 'merge_group'[\s\S]*github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  );
+  assert.match(required, /needs:[\s\S]*- candidate_review/);
+  assert.match(required, /timeout-minutes: 30/);
+  assert.match(
+    required,
+    /needs\.candidate_review\.result != 'success'[\s\S]*run: exit 1/,
+  );
+  assert.match(required, /operation: merge-group-feedback-gate/);
+  assert.match(required, /github_token: \$\{\{ github\.token \}\}/);
+  for (const [input, expression] of Object.entries({
+    event_repository: "github.event.repository.full_name",
+    event_action: "github.event.action",
+    merge_group_head_sha: "github.event.merge_group.head_sha",
+    merge_group_base_sha: "github.event.merge_group.base_sha",
+    merge_group_base_ref: "github.event.merge_group.base_ref",
+    merge_group_head_ref: "github.event.merge_group.head_ref",
+  })) {
+    assertExactExpression(required, input, expression);
+  }
+  assert.match(
+    required,
+    new RegExp(NATIVE_REF.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+  assert.doesNotMatch(
+    required,
+    /actions\/checkout|download-artifact|actions\/cache|automation_token:|continue-on-error:|secrets\.|uses:\s*\.\//,
+  );
+});
+
+test("the privileged-trigger exception documents both trusted paths", () => {
+  assert.match(zizmorConfig, /workflow_run and pull_request_target jobs/);
+  assert.match(
+    zizmorConfig,
+    /never check out or\s*#\s*execute pull-request content/,
+  );
+});
+
+test("internal reusable Actions identify their component release families", () => {
+  assert.match(
+    zizmorWorkflow,
+    new RegExp(ZIZMOR_REF.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+  assert.match(
+    codeqlWorkflow,
+    new RegExp(CODEQL_SARIF_REF.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+});

--- a/.github/scripts/native-auto-merge-workflows.regression.mjs
+++ b/.github/scripts/native-auto-merge-workflows.regression.mjs
@@ -114,6 +114,7 @@ test("the trusted controller exposes both pinned v2.1.4 wake-up paths", () => {
 });
 
 test("the existing Dependency Review context becomes the clean merge-group gate", () => {
+  const boundaries = jobBody(dependencyReview, "workflow_boundaries");
   const candidate = jobBody(dependencyReview, "candidate_review");
   const required = jobBody(dependencyReview, "dependency_review");
 
@@ -122,11 +123,21 @@ test("the existing Dependency Review context becomes the clean merge-group gate"
     /merge_group:[\s\S]*checks_requested/,
   );
   assert.match(candidate, /name: Dependency Review candidate/);
+  assert.match(boundaries, /permissions:[\s\S]*contents: read/);
+  assert.doesNotMatch(boundaries, /write-all/);
+  assert.match(
+    boundaries,
+    /actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1[\s\S]*persist-credentials: false/,
+  );
+  assert.match(
+    boundaries,
+    /node --test \.github\/scripts\/native-auto-merge-workflows\.regression\.mjs/,
+  );
   assert.match(
     candidate,
     /actions\/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294/,
   );
-  assert.match(
+  assert.doesNotMatch(
     candidate,
     /node --test \.github\/scripts\/native-auto-merge-workflows\.regression\.mjs/,
   );
@@ -136,11 +147,22 @@ test("the existing Dependency Review context becomes the clean merge-group gate"
     required,
     /github\.event_name == 'merge_group'[\s\S]*github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
   );
-  assert.match(required, /needs:[\s\S]*- candidate_review/);
+  assert.match(
+    required,
+    /needs:[\s\S]*- workflow_boundaries[\s\S]*- candidate_review/,
+  );
   assert.match(required, /timeout-minutes: 30/);
   assert.match(
     required,
-    /needs\.candidate_review\.result != 'success'[\s\S]*run: exit 1/,
+    /needs\.workflow_boundaries\.result != 'success'[\s\S]*needs\.candidate_review\.result != 'success'[\s\S]*run: exit 1/,
+  );
+  assert.ok(
+    (required.match(/needs\.workflow_boundaries\.result == 'success'/g) ?? [])
+      .length >= 2,
+  );
+  assert.ok(
+    (required.match(/needs\.candidate_review\.result == 'success'/g) ?? [])
+      .length >= 2,
   );
   assert.match(required, /operation: merge-group-feedback-gate/);
   assert.match(required, /github_token: \$\{\{ github\.token \}\}/);

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,6 @@ jobs:
           output: ${{ runner.temp }}/codeql-results
 
       - name: Enforce zero CodeQL findings
-        uses: LCV-Ideas-Software/.github/codeql-sarif-gate@24b0bcc09a48b47f740b8a8bd972374f7289e48e # codeql-sarif-v1.0.0
+        uses: LCV-Ideas-Software/.github/codeql-sarif-gate@24b0bcc09a48b47f740b8a8bd972374f7289e48e # codeql-sarif-gate/v1.0.0
         with:
           sarif-directory: ${{ runner.temp }}/codeql-results

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,9 +11,9 @@ concurrency:
   group: dependency-review-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  dependency-review:
+  candidate_review:
     permissions: write-all
-    name: Dependency Review
+    name: Dependency Review candidate
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Test native auto-merge workflow boundaries
+        run: node --test .github/scripts/native-auto-merge-workflows.regression.mjs
       - name: Review pull request dependencies
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
@@ -36,3 +38,40 @@ jobs:
           head-ref: ${{ github.event.merge_group.head_sha }}
           fail-on-severity: low
           fail-on-scopes: runtime, development, unknown
+
+  dependency_review:
+    permissions: write-all
+    name: Dependency Review
+    if: >-
+      ${{
+        always() &&
+        (
+          github.event_name == 'merge_group' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
+    needs:
+      - candidate_review
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Reject unsuccessful dependency review candidate
+        if: ${{ needs.candidate_review.result != 'success' }}
+        run: exit 1
+
+      - name: Preserve the required dependency review context
+        if: ${{ github.event_name != 'merge_group' && needs.candidate_review.result == 'success' }}
+        run: echo "Dependency review candidate passed."
+
+      - name: Enforce merge-group feedback gate
+        if: ${{ github.event_name == 'merge_group' && needs.candidate_review.result == 'success' }}
+        uses: LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4
+        with:
+          operation: merge-group-feedback-gate
+          github_token: ${{ github.token }}
+          event_repository: ${{ github.event.repository.full_name }}
+          event_action: ${{ github.event.action }}
+          merge_group_head_sha: ${{ github.event.merge_group.head_sha }}
+          merge_group_base_sha: ${{ github.event.merge_group.base_sha }}
+          merge_group_base_ref: ${{ github.event.merge_group.base_ref }}
+          merge_group_head_ref: ${{ github.event.merge_group.head_ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,20 @@ concurrency:
   group: dependency-review-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  workflow_boundaries:
+    permissions:
+      contents: read
+    name: Native auto-merge workflow boundaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Test native auto-merge workflow boundaries
+        run: node --test .github/scripts/native-auto-merge-workflows.regression.mjs
+
   candidate_review:
     permissions: write-all
     name: Dependency Review candidate
@@ -21,8 +35,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Test native auto-merge workflow boundaries
-        run: node --test .github/scripts/native-auto-merge-workflows.regression.mjs
       - name: Review pull request dependencies
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
@@ -51,20 +63,35 @@ jobs:
         )
       }}
     needs:
+      - workflow_boundaries
       - candidate_review
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Reject unsuccessful dependency review candidate
-        if: ${{ needs.candidate_review.result != 'success' }}
+      - name: Reject unsuccessful dependency review prerequisite
+        if: >-
+          ${{
+            needs.workflow_boundaries.result != 'success' ||
+            needs.candidate_review.result != 'success'
+          }}
         run: exit 1
 
       - name: Preserve the required dependency review context
-        if: ${{ github.event_name != 'merge_group' && needs.candidate_review.result == 'success' }}
+        if: >-
+          ${{
+            github.event_name != 'merge_group' &&
+            needs.workflow_boundaries.result == 'success' &&
+            needs.candidate_review.result == 'success'
+          }}
         run: echo "Dependency review candidate passed."
 
       - name: Enforce merge-group feedback gate
-        if: ${{ github.event_name == 'merge_group' && needs.candidate_review.result == 'success' }}
+        if: >-
+          ${{
+            github.event_name == 'merge_group' &&
+            needs.workflow_boundaries.result == 'success' &&
+            needs.candidate_review.result == 'success'
+          }}
         uses: LCV-Ideas-Software/.github/native-auto-merge@231cd33f27c260a6b01fec26aa1d0eb606e1ee2d # native-auto-merge/v2.1.4
         with:
           operation: merge-group-feedback-gate

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
   zizmor:
     name: Run zizmor
     permissions: write-all
-    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0
+    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # zizmor/v2.0.0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -11,6 +11,7 @@ rules:
     disable: true
   dangerous-triggers:
     ignore:
-      # The workflow_run job consumes only trusted default-branch code and never
-      # checks out or downloads content from the triggering pull request.
+      # The workflow_run and pull_request_target jobs consume only the pinned
+      # central Action, validate live GitHub state, and never check out or
+      # execute pull-request content.
       - native-auto-merge.yml


### PR DESCRIPTION
## Transportadora temporária — não fazer merge

Este draft existe somente para produzir os resultados exigidos pela ruleset Enterprise 20613778 no SHA assinado `bf2fbc7264fcdce65b8fbfa85b5782ed65475767`. A ruleset exige CodeQL, Zizmor, Code Quality, License Compliance e Copilot review antes de aceitar a atualização da branch do PR original, portanto o SHA precisa primeiro se tornar alcançável em uma branch nova.

Correção transportada do PR #188:

- move o teste estrutural controlado pelo PR para um job isolado com `contents: read`;
- mantém `persist-credentials: false`;
- preserva a política aceita `permissions: write-all` nos jobs candidate/final;
- faz o contexto final `Dependency Review` depender de structural + candidate e falhar fechado.

Após todos os scanners concluírem no SHA exato, a branch do PR #188 será atualizada com lease, esta transportadora será fechada sem merge e sua branch será removida. Toda revisão e resolução permanecem no PR original.