### PR TITLE
docs: build Pages output before local preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ Use Cloudflare's native dashboard configuration:
 3. Set the variable name to `BIGDATA_DB` and select the D1 database.
 4. Redeploy the project so the binding takes effect.
 
-For local development, pass the identifier directly to Wrangler without storing
-it in the repository:
+For local development, build `dist` first, then pass the identifier directly to
+Wrangler without storing it in the repository:
 
 ```bash
+npm run build
 npx wrangler pages dev dist --d1 BIGDATA_DB=<DATABASE_ID>
 ```
 


### PR DESCRIPTION
## Correção pós-merge de #193

O review Copilot do head de #193 terminou três segundos depois do merge e identificou uma instrução inválida: `wrangler pages dev dist` aparecia antes de `dist` ser criado.

Este follow-up faz somente o necessário:

- documenta `npm run build` antes do preview local;
- mantém o comando oficial `wrangler pages dev` e o binding D1 oficial;
- não adiciona workflow, gate ou implementação customizada.

## Verificação

- diff de um arquivo, 3 inserções/2 remoções;
- árvore candidata idêntica ao snapshot completo já validado com 73/73 testes, Biome, build e formato público verdes;
- `git diff --check` verde;
- commit GPG assinado.