### PR TITLE
fix: valida parâmetros financeiros do ambiente

### DIFF
--- a/functions/api/__tests__/calcular.test.mjs
+++ b/functions/api/__tests__/calcular.test.mjs
@@ -119,6 +119,109 @@ it('mantém precedência D1 sobre payload e ambiente nos limiares percentuais', 
   expect(body.parametros_vigentes.backtest_mape_atencao_percent).toBe(3);
 });
 
+it('mantém precedência D1 sobre payload e ambiente nos parâmetros financeiros', async () => {
+  vi.stubGlobal('fetch', () => {
+    throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');
+  });
+  const res = await onRequestPost({
+    request: req({
+      data_compra: '2026-07-08',
+      moeda: 'USD',
+      valor_original: 100,
+      spread_percent: 6,
+      iof_percent: 4.5,
+      global_spread_aberto_percent: 1.5,
+    }),
+    env: envComPtax(
+      5,
+      {
+        TAXA_SPREAD: '0.08',
+        TAXA_IOF: '0.04',
+        TAXA_IOF_GLOBAL: '0.03',
+        TAXA_SPREAD_GLOBAL_ABERTO: '0.02',
+        TAXA_SPREAD_GLOBAL_FECHADO: '0.03',
+        FATOR_CALIBRAGEM_GLOBAL: '0.98',
+      },
+      [
+        { chave: 'spread_cartao', valor: '0.05' },
+        { chave: 'iof_global', valor: '0.01' },
+        { chave: 'fator_calibragem_global', valor: '0.97' },
+      ],
+    ),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes).toMatchObject({
+    spread_cartao: 0.05,
+    iof_cartao: 0.045,
+    iof_global: 0.01,
+    spread_global_aberto: 0.015,
+    spread_global_fechado: 0.03,
+    fator_calibragem_global: 0.97,
+  });
+});
+
+it('ignora parâmetros financeiros inválidos do ambiente e preserva defaults finitos', async () => {
+  vi.stubGlobal('fetch', () => {
+    throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');
+  });
+  const res = await onRequestPost({
+    request: req({ data_compra: '2026-07-08', moeda: 'USD', valor_original: 100 }),
+    env: envComPtax(5, {
+      TAXA_SPREAD: '',
+      TAXA_IOF: 'NaN',
+      TAXA_IOF_GLOBAL: 'infinito',
+      TAXA_SPREAD_GLOBAL_ABERTO: '?',
+      TAXA_SPREAD_GLOBAL_FECHADO: '!',
+      FATOR_CALIBRAGEM_GLOBAL: 'n/a',
+    }),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes).toMatchObject({
+    spread_cartao: 0.055,
+    iof_cartao: 0.035,
+    iof_global: 0.035,
+    spread_global_aberto: 0.0078,
+    spread_global_fechado: 0.0118,
+    fator_calibragem_global: 0.99934,
+  });
+  expect(body.cartao.valor_total_brl).toBe(545.96);
+  expect(body.cartao.vet).toBe(5.459625);
+});
+
+it('aceita zero finito do ambiente sem substituí-lo pelos defaults', async () => {
+  vi.stubGlobal('fetch', () => {
+    throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');
+  });
+  const res = await onRequestPost({
+    request: req({ data_compra: '2026-07-08', moeda: 'USD', valor_original: 100 }),
+    env: envComPtax(5, {
+      TAXA_SPREAD: '0',
+      TAXA_IOF: '0',
+      TAXA_IOF_GLOBAL: '0',
+      TAXA_SPREAD_GLOBAL_ABERTO: '0',
+      TAXA_SPREAD_GLOBAL_FECHADO: '0',
+      FATOR_CALIBRAGEM_GLOBAL: '0',
+    }),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes).toMatchObject({
+    spread_cartao: 0,
+    iof_cartao: 0,
+    iof_global: 0,
+    spread_global_aberto: 0,
+    spread_global_fechado: 0,
+    fator_calibragem_global: 0,
+  });
+  expect(body.cartao.valor_total_brl).toBe(500);
+  expect(body.cartao.vet).toBe(5);
+});
+
 it('usa ambiente válido e depois defaults para ambiente ausente ou inválido quando o payload não é finito', async () => {
   vi.stubGlobal('fetch', () => {
     throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');

--- a/functions/api/calcular.js
+++ b/functions/api/calcular.js
@@ -68,11 +68,18 @@ export async function onRequestPost(context) {
             } catch (e2) { }
         }
 
+        const readFiniteEnv = (envKey) => {
+            if (!envKey || env[envKey] === undefined) return undefined;
+            const value = parseFloat(env[envKey]);
+            return Number.isFinite(value) ? value : undefined;
+        };
+
         // Resolver valores finais (D1 > payload > env > default)
         const resolveParam = (d1Key, payloadVal, envKey, fallback) => {
             if (d1Key in parametrosD1) return parametrosD1[d1Key];
             if (Number.isFinite(payloadVal)) return payloadVal / 100; // payload vem em %
-            if (envKey && env[envKey]) return parseFloat(env[envKey]);
+            const envValue = readFiniteEnv(envKey);
+            if (envValue !== undefined) return envValue;
             return fallback;
         };
 
@@ -81,16 +88,15 @@ export async function onRequestPost(context) {
         const IOF_GLOBAL = resolveParam('iof_global', iofPercentInformado, 'TAXA_IOF_GLOBAL', 0.035);
         const SPREAD_GLOBAL_ABERTO = resolveParam('spread_global_aberto', globalSpreadAbertoInformado, 'TAXA_SPREAD_GLOBAL_ABERTO', 0.0078);
         const SPREAD_GLOBAL_FECHADO = resolveParam('spread_global_fechado', globalSpreadFechadoInformado, 'TAXA_SPREAD_GLOBAL_FECHADO', 0.0118);
-        const CALIBRAGEM = ('fator_calibragem_global' in parametrosD1) ? parametrosD1.fator_calibragem_global : (env.FATOR_CALIBRAGEM_GLOBAL ? parseFloat(env.FATOR_CALIBRAGEM_GLOBAL) : 0.99934);
+        const calibragemEnv = readFiniteEnv('FATOR_CALIBRAGEM_GLOBAL');
+        const CALIBRAGEM = ('fator_calibragem_global' in parametrosD1) ? parametrosD1.fator_calibragem_global : (calibragemEnv ?? 0.99934);
         if ('fator_calibragem_global' in parametrosD1) origem.fator_calibragem_global = 'd1';
 
         const resolveMetricParam = (d1Key, payloadVal, envKey, fallback) => {
             if (d1Key in parametrosD1 && Number.isFinite(parametrosD1[d1Key])) return parametrosD1[d1Key];
             if (Number.isFinite(payloadVal)) return payloadVal;
-            if (envKey && env[envKey] !== undefined) {
-                const v = parseFloat(env[envKey]);
-                if (Number.isFinite(v)) return v;
-            }
+            const envValue = readFiniteEnv(envKey);
+            if (envValue !== undefined) return envValue;
             return fallback;
         };
 


### PR DESCRIPTION
## Problema

Bindings financeiros de ambiente eram aceitos apenas por serem truthy e passados a `parseFloat` sem validar finitude. Strings inválidas viravam `NaN`; a resposta HTTP 200 serializava parâmetros, total do cartão e VET como `null`.

## Mudança

- centraliza leitura de env em `readFiniteEnv`;
- mantém a precedência D1 > payload > env > default;
- usa defaults para env ausente, vazio ou não finito;
- preserva zero finito;
- adiciona testes de precedência, regressão de env inválido/vazio e zero.

## Evidência

RED pré-edição em `origin/main@09eb7b2`: seis parâmetros financeiros, `cartao.valor_total_brl` e `cartao.vet` retornaram `null`; exit 1.

Gates finais:

- teste focado: 10/10;
- `npm test`: 76/76;
- `npm run biome`: exit 0 (apenas aviso informativo de configuração deprecated);
- `npm run format:public:check`: exit 0;
- `npm run build`: exit 0;
- diff exato: `4e875ab1968fee472377cd06c77dbc8e90be729a4c5225563650ee480f1e1038`;
- commit assinado e verificado pelo GitHub.

## Revisão independente

A rodada final teve quatro `READY` limpos — Claude, DeepSeek, Grok e Perplexity — sem objeções. Gemini foi ignorado por indisponibilidade (403 spend cap).

A sessão permaneceu literalmente `converged:false` apenas porque sete pedidos antigos da primeira evidência inválida ficaram como `not_resurfaced`, apesar do diff e dos testes solicitados terem sido enviados e aceitos pelos quatro revisores na rodada final.

Gate posterior no head exato `d33f89f5a1ca6e7adedba449df0579bd192c1ecb`: GitHub Codex não encontrou nenhum problema relevante. O PR foi marcado ready e encaminhado à merge queue por decisão do operador.

Refs #182