### PR TITLE
test(d1): add sanitized production contract

### DIFF
--- a/functions/api/__tests__/d1-contract.test.mjs
+++ b/functions/api/__tests__/d1-contract.test.mjs
@@ -7,12 +7,16 @@ function validSnapshot() {
       table_name: table,
       column_name: column,
       pk_position: (D1_CONTRACT.primaryKeys[table] ?? []).indexOf(column) + 1,
+      not_null: table === 'ai_usage_logs' && column === 'timestamp' ? 1 : 0,
+      default_value: table === 'ai_usage_logs' && column === 'timestamp' ? "datetime('now')" : null,
     })),
   );
   schema.push({
     table_name: 'shared_extra_table',
     column_name: 'id',
     pk_position: 1,
+    not_null: 0,
+    default_value: null,
   });
 
   const indexes = Object.entries(D1_CONTRACT.indexes).flatMap(([name, index]) =>
@@ -21,6 +25,8 @@ function validSnapshot() {
       table_name: index.table,
       column_name: column,
       column_position: position,
+      is_unique: 0,
+      is_partial: 0,
     })),
   );
   indexes.push({
@@ -28,6 +34,8 @@ function validSnapshot() {
     table_name: 'shared_extra_table',
     column_name: 'id',
     column_position: 0,
+    is_unique: 0,
+    is_partial: 0,
   });
 
   const retention = Object.entries(D1_CONTRACT.retention).map(([table, maxAgeDays]) => ({
@@ -65,6 +73,7 @@ describe('contrato sanitizado do D1 compartilhado', () => {
         'index positions mismatch: idx_calc_rate_limit_hits_lookup expected [0, 1, 2] got [0, 1]',
         'missing column: calc_oraculo_observabilidade.valor_original',
         'primary key mismatch: calc_ptax_cache expected [data_cotacao, moeda] got [data_cotacao]',
+        'primary key positions mismatch: calc_ptax_cache expected [1, 2] got [1]',
         'retention violation: ai_usage_logs has 1 stale row(s)',
       ],
     });
@@ -94,5 +103,54 @@ describe('contrato sanitizado do D1 compartilhado', () => {
       calc_oraculo_observabilidade: 90,
       ai_usage_logs: 90,
     });
+  });
+
+  it('rejeita índices canônicos UNIQUE ou parciais', () => {
+    const snapshot = validSnapshot();
+    snapshot.indexes = snapshot.indexes.map((row) => {
+      if (row.index_name === 'idx_calc_backtest_created_at') return { ...row, is_unique: 1 };
+      if (row.index_name === 'idx_calc_rate_limit_hits_lookup') return { ...row, is_partial: 1 };
+      return row;
+    });
+
+    const result = verifyD1Contract(snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('index must be non-unique: idx_calc_backtest_created_at');
+    expect(result.errors).toContain('index must be non-partial: idx_calc_rate_limit_hits_lookup');
+  });
+
+  it('exige a PK de políticas e posições PK canônicas sem lacunas', () => {
+    const snapshot = validSnapshot();
+    snapshot.schema = snapshot.schema.map((row) => {
+      if (row.table_name === 'calc_rate_limit_policies' && row.column_name === 'route_key') {
+        return { ...row, pk_position: 0 };
+      }
+      if (row.table_name === 'calc_ptax_cache' && row.column_name === 'data_cotacao') {
+        return { ...row, pk_position: 2 };
+      }
+      if (row.table_name === 'calc_ptax_cache' && row.column_name === 'moeda') {
+        return { ...row, pk_position: 3 };
+      }
+      return row;
+    });
+
+    const result = verifyD1Contract(snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('primary key mismatch: calc_rate_limit_policies expected [route_key] got []');
+    expect(result.errors).toContain('primary key positions mismatch: calc_ptax_cache expected [1, 2] got [2, 3]');
+  });
+
+  it('exige NOT NULL e default temporal na telemetria de IA', () => {
+    const snapshot = validSnapshot();
+    snapshot.schema = snapshot.schema.map((row) =>
+      row.table_name === 'ai_usage_logs' && row.column_name === 'timestamp'
+        ? { ...row, not_null: 0, default_value: null }
+        : row,
+    );
+
+    const result = verifyD1Contract(snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('column must be NOT NULL: ai_usage_logs.timestamp');
+    expect(result.errors).toContain("column default mismatch: ai_usage_logs.timestamp expected datetime('now') got null");
   });
 });

--- a/functions/api/__tests__/d1-contract.test.mjs
+++ b/functions/api/__tests__/d1-contract.test.mjs
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { D1_CONTRACT, verifyD1Contract } from '../../../scripts/verify-d1-contract.mjs';
+
+function validSnapshot() {
+  const schema = Object.entries(D1_CONTRACT.tables).flatMap(([table, columns]) =>
+    columns.map((column) => ({
+      table_name: table,
+      column_name: column,
+      pk_position: (D1_CONTRACT.primaryKeys[table] ?? []).indexOf(column) + 1,
+    })),
+  );
+  schema.push({
+    table_name: 'shared_extra_table',
+    column_name: 'id',
+    pk_position: 1,
+  });
+
+  const indexes = Object.entries(D1_CONTRACT.indexes).flatMap(([name, index]) =>
+    index.columns.map((column, position) => ({
+      index_name: name,
+      table_name: index.table,
+      column_name: column,
+      column_position: position,
+    })),
+  );
+  indexes.push({
+    index_name: 'shared_extra_index',
+    table_name: 'shared_extra_table',
+    column_name: 'id',
+    column_position: 0,
+  });
+
+  const retention = Object.entries(D1_CONTRACT.retention).map(([table, maxAgeDays]) => ({
+    table_name: table,
+    max_age_days: maxAgeDays,
+    stale_rows: 0,
+  }));
+
+  return { schema, indexes, retention };
+}
+
+describe('contrato sanitizado do D1 compartilhado', () => {
+  it('aceita o contrato ativo e ignora objetos extras do banco compartilhado', () => {
+    expect(verifyD1Contract(validSnapshot())).toEqual({ ok: true, errors: [] });
+  });
+
+  it('falha fechado para drift de coluna, PK, índice e retenção', () => {
+    const snapshot = validSnapshot();
+    snapshot.schema = snapshot.schema
+      .filter((row) => !(row.table_name === 'calc_oraculo_observabilidade' && row.column_name === 'valor_original'))
+      .map((row) =>
+        row.table_name === 'calc_ptax_cache' && row.column_name === 'moeda' ? { ...row, pk_position: 0 } : row,
+      );
+    snapshot.indexes = snapshot.indexes.filter(
+      (row) => !(row.index_name === 'idx_calc_rate_limit_hits_lookup' && row.column_name === 'created_at'),
+    );
+    snapshot.retention = snapshot.retention.map((row) =>
+      row.table_name === 'ai_usage_logs' ? { ...row, stale_rows: 1 } : row,
+    );
+
+    expect(verifyD1Contract(snapshot)).toEqual({
+      ok: false,
+      errors: [
+        'index columns mismatch: idx_calc_rate_limit_hits_lookup expected [route_key, ip, created_at] got [route_key, ip]',
+        'index positions mismatch: idx_calc_rate_limit_hits_lookup expected [0, 1, 2] got [0, 1]',
+        'missing column: calc_oraculo_observabilidade.valor_original',
+        'primary key mismatch: calc_ptax_cache expected [data_cotacao, moeda] got [data_cotacao]',
+        'retention violation: ai_usage_logs has 1 stale row(s)',
+      ],
+    });
+  });
+
+  it('falha fechado quando posição de índice ou contagem de retenção é nula', () => {
+    const snapshot = validSnapshot();
+    snapshot.indexes = snapshot.indexes.map((row) =>
+      row.index_name === 'idx_calc_backtest_created_at' ? { ...row, column_position: null } : row,
+    );
+    snapshot.retention = snapshot.retention.map((row) =>
+      row.table_name === 'ai_usage_logs' ? { ...row, stale_rows: null } : row,
+    );
+
+    expect(verifyD1Contract(snapshot)).toEqual({
+      ok: false,
+      errors: [
+        'invalid index position: idx_calc_backtest_created_at',
+        'missing index: idx_calc_backtest_created_at',
+        'retention violation: ai_usage_logs has null stale row(s)',
+      ],
+    });
+  });
+
+  it('mantém a janela LGPD canônica em 90 dias para as duas telemetrias', () => {
+    expect(D1_CONTRACT.retention).toEqual({
+      calc_oraculo_observabilidade: 90,
+      ai_usage_logs: 90,
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "verify:d1-contract": "node scripts/verify-d1-contract.mjs",
     "format": "biome format --write src",
     "lint": "biome check src",
     "biome": "biome check .",

--- a/scripts/verify-d1-contract.mjs
+++ b/scripts/verify-d1-contract.mjs
@@ -43,6 +43,7 @@ export const D1_CONTRACT = Object.freeze({
   },
   primaryKeys: {
     calc_ptax_cache: ['data_cotacao', 'moeda'],
+    calc_rate_limit_policies: ['route_key'],
   },
   indexes: {
     idx_calc_backtest_created_at: {
@@ -58,6 +59,12 @@ export const D1_CONTRACT = Object.freeze({
     calc_oraculo_observabilidade: 90,
     ai_usage_logs: 90,
   },
+  columnConstraints: {
+    'ai_usage_logs.timestamp': {
+      notNull: true,
+      defaultValue: "datetime('now')",
+    },
+  },
 });
 
 const sameOrderedValues = (actual, expected) =>
@@ -71,16 +78,18 @@ export function verifyD1Contract(snapshot) {
 
   const columnsByTable = new Map();
   const primaryKeysByTable = new Map();
+  const schemaByColumn = new Map();
   for (const row of schemaRows) {
     if (typeof row?.table_name !== 'string' || typeof row?.column_name !== 'string') continue;
+    schemaByColumn.set(`${row.table_name}.${row.column_name}`, row);
     const columns = columnsByTable.get(row.table_name) ?? [];
     columns.push(row.column_name);
     columnsByTable.set(row.table_name, columns);
-    if (Number(row.pk_position) > 0) {
+    if (Number.isInteger(row.pk_position) && row.pk_position > 0) {
       const primaryKeys = primaryKeysByTable.get(row.table_name) ?? [];
       primaryKeys.push({
         column: row.column_name,
-        position: Number(row.pk_position),
+        position: row.pk_position,
       });
       primaryKeysByTable.set(row.table_name, primaryKeys);
     }
@@ -98,13 +107,30 @@ export function verifyD1Contract(snapshot) {
   }
 
   for (const [table, expectedColumns] of Object.entries(D1_CONTRACT.primaryKeys)) {
-    const actualColumns = (primaryKeysByTable.get(table) ?? [])
-      .sort((left, right) => left.position - right.position)
-      .map(({ column }) => column);
+    const actual = (primaryKeysByTable.get(table) ?? []).sort((left, right) => left.position - right.position);
+    const actualColumns = actual.map(({ column }) => column);
     if (!sameOrderedValues(actualColumns, expectedColumns)) {
       errors.push(
         `primary key mismatch: ${table} expected [${expectedColumns.join(', ')}] got [${actualColumns.join(', ')}]`,
       );
+    }
+    const actualPositions = actual.map(({ position }) => position);
+    const expectedPositions = expectedColumns.map((_, index) => index + 1);
+    if (!sameOrderedValues(actualPositions, expectedPositions)) {
+      errors.push(
+        `primary key positions mismatch: ${table} expected [${expectedPositions.join(', ')}] got [${actualPositions.join(', ')}]`,
+      );
+    }
+  }
+
+  for (const [key, constraint] of Object.entries(D1_CONTRACT.columnConstraints)) {
+    const actual = schemaByColumn.get(key);
+    if (!actual) continue;
+    if (constraint.notNull && actual.not_null !== 1) {
+      errors.push(`column must be NOT NULL: ${key}`);
+    }
+    if (actual.default_value !== constraint.defaultValue) {
+      errors.push(`column default mismatch: ${key} expected ${constraint.defaultValue} got ${actual.default_value}`);
     }
   }
 
@@ -125,8 +151,12 @@ export function verifyD1Contract(snapshot) {
     const index = indexesByName.get(row.index_name) ?? {
       tables: new Set(),
       columns: [],
+      uniqueFlags: new Set(),
+      partialFlags: new Set(),
     };
     index.tables.add(row.table_name);
+    index.uniqueFlags.add(row.is_unique);
+    index.partialFlags.add(row.is_partial);
     index.columns.push({
       column: row.column_name,
       position: row.column_position,
@@ -146,6 +176,12 @@ export function verifyD1Contract(snapshot) {
     const actualTables = [...actual.tables].sort();
     if (actualTables.length !== 1 || actualTables[0] !== expected.table) {
       errors.push(`index table mismatch: ${name} expected ${expected.table} got [${actualTables.join(', ')}]`);
+    }
+    if (actual.uniqueFlags.size !== 1 || !actual.uniqueFlags.has(0)) {
+      errors.push(`index must be non-unique: ${name}`);
+    }
+    if (actual.partialFlags.size !== 1 || !actual.partialFlags.has(0)) {
+      errors.push(`index must be non-partial: ${name}`);
     }
     const orderedColumns = actual.columns.sort((left, right) => left.position - right.position);
     const actualColumns = orderedColumns.map(({ column }) => column);

--- a/scripts/verify-d1-contract.mjs
+++ b/scripts/verify-d1-contract.mjs
@@ -1,0 +1,214 @@
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const D1_CONTRACT = Object.freeze({
+  tables: {
+    calc_parametros_customizados: ['id', 'chave', 'valor'],
+    calc_ptax_cache: ['data_cotacao', 'moeda', 'valor_ptax'],
+    calc_backtest_spot_vs_ptax: [
+      'id',
+      'created_at',
+      'moeda',
+      'data_compra',
+      'taxa_prevista',
+      'taxa_observada',
+      'erro_percentual',
+    ],
+    calc_oraculo_observabilidade: [
+      'id',
+      'created_at',
+      'status',
+      'from_cache',
+      'force_refresh',
+      'duration_ms',
+      'moeda',
+      'valor_original',
+      'preview',
+      'error_message',
+      'app_version',
+    ],
+    calc_rate_limit_policies: ['route_key', 'enabled', 'max_requests', 'window_minutes', 'updated_at', 'updated_by'],
+    calc_rate_limit_hits: ['id', 'route_key', 'ip', 'created_at'],
+    ai_usage_logs: [
+      'id',
+      'timestamp',
+      'module',
+      'model',
+      'input_tokens',
+      'output_tokens',
+      'latency_ms',
+      'status',
+      'error_detail',
+    ],
+  },
+  primaryKeys: {
+    calc_ptax_cache: ['data_cotacao', 'moeda'],
+  },
+  indexes: {
+    idx_calc_backtest_created_at: {
+      table: 'calc_backtest_spot_vs_ptax',
+      columns: ['created_at'],
+    },
+    idx_calc_rate_limit_hits_lookup: {
+      table: 'calc_rate_limit_hits',
+      columns: ['route_key', 'ip', 'created_at'],
+    },
+  },
+  retention: {
+    calc_oraculo_observabilidade: 90,
+    ai_usage_logs: 90,
+  },
+});
+
+const sameOrderedValues = (actual, expected) =>
+  actual.length === expected.length && actual.every((value, index) => value === expected[index]);
+
+export function verifyD1Contract(snapshot) {
+  const errors = [];
+  const schemaRows = Array.isArray(snapshot?.schema) ? snapshot.schema : [];
+  const indexRows = Array.isArray(snapshot?.indexes) ? snapshot.indexes : [];
+  const retentionRows = Array.isArray(snapshot?.retention) ? snapshot.retention : [];
+
+  const columnsByTable = new Map();
+  const primaryKeysByTable = new Map();
+  for (const row of schemaRows) {
+    if (typeof row?.table_name !== 'string' || typeof row?.column_name !== 'string') continue;
+    const columns = columnsByTable.get(row.table_name) ?? [];
+    columns.push(row.column_name);
+    columnsByTable.set(row.table_name, columns);
+    if (Number(row.pk_position) > 0) {
+      const primaryKeys = primaryKeysByTable.get(row.table_name) ?? [];
+      primaryKeys.push({
+        column: row.column_name,
+        position: Number(row.pk_position),
+      });
+      primaryKeysByTable.set(row.table_name, primaryKeys);
+    }
+  }
+
+  for (const [table, requiredColumns] of Object.entries(D1_CONTRACT.tables)) {
+    const actualColumns = columnsByTable.get(table);
+    if (!actualColumns) {
+      errors.push(`missing table: ${table}`);
+      continue;
+    }
+    for (const column of requiredColumns) {
+      if (!actualColumns.includes(column)) errors.push(`missing column: ${table}.${column}`);
+    }
+  }
+
+  for (const [table, expectedColumns] of Object.entries(D1_CONTRACT.primaryKeys)) {
+    const actualColumns = (primaryKeysByTable.get(table) ?? [])
+      .sort((left, right) => left.position - right.position)
+      .map(({ column }) => column);
+    if (!sameOrderedValues(actualColumns, expectedColumns)) {
+      errors.push(
+        `primary key mismatch: ${table} expected [${expectedColumns.join(', ')}] got [${actualColumns.join(', ')}]`,
+      );
+    }
+  }
+
+  const indexesByName = new Map();
+  const invalidIndexPositions = new Set();
+  for (const row of indexRows) {
+    if (
+      typeof row?.index_name !== 'string' ||
+      typeof row?.table_name !== 'string' ||
+      typeof row?.column_name !== 'string'
+    ) {
+      continue;
+    }
+    if (!Number.isInteger(row.column_position)) {
+      invalidIndexPositions.add(row.index_name);
+      continue;
+    }
+    const index = indexesByName.get(row.index_name) ?? {
+      tables: new Set(),
+      columns: [],
+    };
+    index.tables.add(row.table_name);
+    index.columns.push({
+      column: row.column_name,
+      position: row.column_position,
+    });
+    indexesByName.set(row.index_name, index);
+  }
+
+  for (const [name, expected] of Object.entries(D1_CONTRACT.indexes)) {
+    if (invalidIndexPositions.has(name)) {
+      errors.push(`invalid index position: ${name}`);
+    }
+    const actual = indexesByName.get(name);
+    if (!actual) {
+      errors.push(`missing index: ${name}`);
+      continue;
+    }
+    const actualTables = [...actual.tables].sort();
+    if (actualTables.length !== 1 || actualTables[0] !== expected.table) {
+      errors.push(`index table mismatch: ${name} expected ${expected.table} got [${actualTables.join(', ')}]`);
+    }
+    const orderedColumns = actual.columns.sort((left, right) => left.position - right.position);
+    const actualColumns = orderedColumns.map(({ column }) => column);
+    if (!sameOrderedValues(actualColumns, expected.columns)) {
+      errors.push(
+        `index columns mismatch: ${name} expected [${expected.columns.join(', ')}] got [${actualColumns.join(', ')}]`,
+      );
+    }
+    const actualPositions = orderedColumns.map(({ position }) => position);
+    const expectedPositions = expected.columns.map((_, position) => position);
+    if (!sameOrderedValues(actualPositions, expectedPositions)) {
+      errors.push(
+        `index positions mismatch: ${name} expected [${expectedPositions.join(', ')}] got [${actualPositions.join(', ')}]`,
+      );
+    }
+  }
+
+  const retentionByTable = new Map(
+    retentionRows.filter((row) => typeof row?.table_name === 'string').map((row) => [row.table_name, row]),
+  );
+  for (const [table, maxAgeDays] of Object.entries(D1_CONTRACT.retention)) {
+    const actual = retentionByTable.get(table);
+    if (!actual) {
+      errors.push(`missing retention evidence: ${table}`);
+      continue;
+    }
+    if (Number(actual.max_age_days) !== maxAgeDays) {
+      errors.push(`retention window mismatch: ${table} expected ${maxAgeDays} got ${actual.max_age_days}`);
+    }
+    if (!Number.isInteger(actual.stale_rows) || actual.stale_rows !== 0) {
+      errors.push(`retention violation: ${table} has ${actual.stale_rows} stale row(s)`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors: errors.sort() };
+}
+
+async function readSnapshot(path) {
+  if (path === '-') {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  }
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function main() {
+  const snapshotPath = process.argv[2];
+  if (!snapshotPath) {
+    console.error('Uso: npm run verify:d1-contract -- <snapshot.json|->');
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = verifyD1Contract(await readSnapshot(snapshotPath));
+  if (!result.ok) {
+    console.error(['D1 contract drift detected:', ...result.errors.map((error) => `- ${error}`)].join('\n'));
+    process.exitCode = 1;
+    return;
+  }
+  console.log('D1 contract verified: required schema metadata, indexes, primary keys and retention match.');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}


### PR DESCRIPTION
## Resumo

- versiona um contrato sanitizado para as sete tabelas D1 ativas da aplicação;
- verifica colunas requeridas, PK composta, dois índices canônicos e retenção de 90 dias;
- falha fechado para drift, evidência incompleta e valores JSON nulos, tolerando objetos compartilhados extras;
- adiciona um CLI por arquivo/stdin e testes focados.

## Diagnóstico

A retenção e os índices já estavam implantados, mas a remoção correta de `schema.sql` deixou a reconciliação produção-vs-repositório sem artefato repetível. O patch registra apenas invariantes necessárias; não reintroduz dump DDL.

## Segurança e LGPD

- nenhum conteúdo de linha, credencial ou identificador real de banco, conta, projeto ou domínio foi versionado;
- o canário de produção foi read-only e consultou somente metadados e contagens agregadas;
- as duas tabelas de telemetria apresentaram zero linhas além da janela de 90 dias;
- nenhuma migration, mutação, prune ou implantação foi executada nesta tranche.

## Validação

- RED inicial: `npm run verify:d1-contract` ausente;
- RED adversarial: `column_position: null` e `stale_rows: null` produziam falso verde antes do endurecimento;
- teste focado: 7/7;
- suíte completa: 80/80;
- `npm run biome`;
- `npm run format:public:check`;
- `npm run build`;
- canário sanitizado read-only: contrato compatível;
- GitHub Codex no head original: quatro falsos-verdes P2 reproduzidos em RED e corrigidos no commit 620465b; threads respondidas e resolvidas;
- cross-review: Claude, DeepSeek, Grok e Perplexity READY limpos; Gemini indisponível por spend cap.

Closes #184