### PR TITLE
fix: rejeita calibragem global não positiva

### DIFF
--- a/functions/api/__tests__/calcular.test.mjs
+++ b/functions/api/__tests__/calcular.test.mjs
@@ -192,7 +192,7 @@ it('ignora parâmetros financeiros inválidos do ambiente e preserva defaults fi
   expect(body.cartao.vet).toBe(5.459625);
 });
 
-it('aceita zero finito do ambiente sem substituí-lo pelos defaults', async () => {
+it('aceita zero finito nas taxas, mas usa o default para calibragem zero', async () => {
   vi.stubGlobal('fetch', () => {
     throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');
   });
@@ -216,10 +216,52 @@ it('aceita zero finito do ambiente sem substituí-lo pelos defaults', async () =
     iof_global: 0,
     spread_global_aberto: 0,
     spread_global_fechado: 0,
-    fator_calibragem_global: 0,
+    fator_calibragem_global: 0.99934,
   });
   expect(body.cartao.valor_total_brl).toBe(500);
   expect(body.cartao.vet).toBe(5);
+});
+
+it('rejeita calibragem global zero e preserva a cotação calibrada sem contingência', async () => {
+  const fetchSpy = vi.fn(async (url) => {
+    if (String(url).includes('economia.awesomeapi.com.br')) {
+      return new Response(JSON.stringify({ USDBRL: { bid: '5' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`fetch inesperado: ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchSpy);
+
+  const db = createD1Stub([
+    {
+      match: (sql) => /FROM calc_parametros_customizados/i.test(sql),
+      all: () => ({ results: [{ chave: 'fator_calibragem_global', valor: '0' }] }),
+    },
+    {
+      match: (sql) => /FROM calc_ptax_cache/i.test(sql),
+      first: (args, sql) => {
+        if (/LATEST_SPOT/i.test(sql) || String(args[0]).startsWith('SPOT-')) return null;
+        return { valor_ptax: 5 };
+      },
+    },
+  ]);
+  const res = await onRequestPost({
+    request: req({ data_compra: '2026-07-08', moeda: 'USD', valor_original: 100 }),
+    env: { BIGDATA_DB: db, FATOR_CALIBRAGEM_GLOBAL: '0' },
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes.fator_calibragem_global).toBe(0.99934);
+  expect(body.global).toMatchObject({
+    suportada: true,
+    fonte_cotacao: 'Spot Calibrado (alt)',
+    usou_contingencia: false,
+  });
+  expect(body.global.taxa_utilizada).toBeCloseTo(4.9967, 8);
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
 });
 
 it('usa ambiente válido e depois defaults para ambiente ausente ou inválido quando o payload não é finito', async () => {

--- a/functions/api/calcular.js
+++ b/functions/api/calcular.js
@@ -88,9 +88,12 @@ export async function onRequestPost(context) {
         const IOF_GLOBAL = resolveParam('iof_global', iofPercentInformado, 'TAXA_IOF_GLOBAL', 0.035);
         const SPREAD_GLOBAL_ABERTO = resolveParam('spread_global_aberto', globalSpreadAbertoInformado, 'TAXA_SPREAD_GLOBAL_ABERTO', 0.0078);
         const SPREAD_GLOBAL_FECHADO = resolveParam('spread_global_fechado', globalSpreadFechadoInformado, 'TAXA_SPREAD_GLOBAL_FECHADO', 0.0118);
+        const calibragemD1 = parametrosD1.fator_calibragem_global;
         const calibragemEnv = readFiniteEnv('FATOR_CALIBRAGEM_GLOBAL');
-        const CALIBRAGEM = ('fator_calibragem_global' in parametrosD1) ? parametrosD1.fator_calibragem_global : (calibragemEnv ?? 0.99934);
-        if ('fator_calibragem_global' in parametrosD1) origem.fator_calibragem_global = 'd1';
+        const calibragemD1Valida = Number.isFinite(calibragemD1) && calibragemD1 > 0;
+        const CALIBRAGEM = calibragemD1Valida ? calibragemD1 : (calibragemEnv > 0 ? calibragemEnv : 0.99934);
+        if (calibragemD1Valida) origem.fator_calibragem_global = 'd1';
+        else delete origem.taxa_fator_calibragem_global;
 
         const resolveMetricParam = (d1Key, payloadVal, envKey, fallback) => {
             if (d1Key in parametrosD1 && Number.isFinite(parametrosD1[d1Key])) return parametrosD1[d1Key];


### PR DESCRIPTION
## Problema

O review GitHub Codex chegou depois do merge queue do PR #201 e identificou uma inconsistência válida: `FATOR_CALIBRAGEM_GLOBAL=0` era anunciado na resposta, mas a cotação externa calibrada virava zero e os checks truthy downstream a tratavam como ausente, acionando contingência sem calibragem.

## Mudança

- aceita fator de calibragem do D1 ou ambiente somente quando finito e estritamente positivo;
- usa o default positivo para zero, negativos e valores inválidos;
- preserva zero finito nas demais taxas;
- remove a origem D1 quando o valor de calibragem é rejeitado;
- cobre cotação externa, ausência de cache e não acionamento da contingência;
- mantém o mock fail-closed: qualquer consulta à fonte de fallback é inesperada.

## Evidência

- RED funcional: teste focado 10/11; esperado `0.99934`, recebido `0`;
- GREEN focado: 11/11;
- RED remoto no primeiro head: CodeQL bloqueou a comparação de hostname por substring no mock;
- correção do alerta: removido o ramo de fallback que contradizia o contrato do teste;
- GREEN após a correção CodeQL: focado 11/11, suíte completa 77/77;
- `npm run biome`: passou, com aviso informativo preexistente;
- `npm run build`: passou;
- `npm run format:public:check`: passou;
- `git diff --check`: passou;
- todos os checks remotos passaram no head exato;
- a revisão automática GitHub Codex pós-ready ficou indisponível por limite de uso, sem novo finding; não foi feita nova solicitação manual;
- commit `dea1f445cc227b06b6d81523a5b7e26d7b7adf6e` assinado.

Follow-up de #201 e da [thread Codex](https://github.com/LCV-Ideas-Software/calculadora-app/pull/201#discussion_r3819832815).

Refs #182