### PR TITLE
fix: alinha a calibragem entre endpoints

### DIFF
--- a/functions/api/__tests__/calcular.test.mjs
+++ b/functions/api/__tests__/calcular.test.mjs
@@ -160,6 +160,8 @@ it('mantém precedência D1 sobre payload e ambiente nos parâmetros financeiros
     spread_global_fechado: 0.03,
     fator_calibragem_global: 0.97,
   });
+  expect(body.parametros_vigentes.origem.taxa_fator_calibragem_global).toBe('d1');
+  expect(body.parametros_vigentes.origem).not.toHaveProperty('fator_calibragem_global');
 });
 
 it('ignora parâmetros financeiros inválidos do ambiente e preserva defaults finitos', async () => {
@@ -220,6 +222,40 @@ it('aceita zero finito nas taxas, mas usa o default para calibragem zero', async
   });
   expect(body.cartao.valor_total_brl).toBe(500);
   expect(body.cartao.vet).toBe(5);
+});
+
+it.each([0, -0.5])('ignora calibragem D1 não positiva (%s) e usa o ambiente positivo', async (invalidFactor) => {
+  vi.stubGlobal('fetch', () => {
+    throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');
+  });
+  const res = await onRequestPost({
+    request: req({ data_compra: '2026-07-08', moeda: 'USD', valor_original: 100 }),
+    env: envComPtax(
+      5,
+      { FATOR_CALIBRAGEM_GLOBAL: '0.98' },
+      [{ chave: 'fator_calibragem_global', valor: String(invalidFactor) }],
+    ),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes.fator_calibragem_global).toBe(0.98);
+  expect(body.parametros_vigentes.origem).not.toHaveProperty('taxa_fator_calibragem_global');
+  expect(body.parametros_vigentes.origem).not.toHaveProperty('fator_calibragem_global');
+});
+
+it.each([0, -0.5])('usa o default quando a calibragem do ambiente não é positiva (%s)', async (invalidFactor) => {
+  vi.stubGlobal('fetch', () => {
+    throw new Error('não deveria chamar rede (cache D1 cobre as cotações)');
+  });
+  const res = await onRequestPost({
+    request: req({ data_compra: '2026-07-08', moeda: 'USD', valor_original: 100 }),
+    env: envComPtax(5, { FATOR_CALIBRAGEM_GLOBAL: String(invalidFactor) }),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes.fator_calibragem_global).toBe(0.99934);
 });
 
 it('rejeita calibragem global zero e preserva a cotação calibrada sem contingência', async () => {

--- a/functions/api/__tests__/parametros.test.mjs
+++ b/functions/api/__tests__/parametros.test.mjs
@@ -1,0 +1,55 @@
+import { expect, it } from 'vitest';
+import { onRequestGet } from '../parametros.js';
+import { createD1Stub } from './helpers/d1-stub.mjs';
+
+function envComParametros(parametros = [], bindings = {}) {
+  return {
+    ...bindings,
+    BIGDATA_DB: createD1Stub([
+      {
+        match: (sql) => /FROM calc_parametros_customizados/i.test(sql),
+        all: () => ({ results: parametros }),
+      },
+    ]),
+  };
+}
+
+it.each([0, -0.5])('ignora calibragem D1 não positiva (%s) e usa o ambiente positivo', async (invalidFactor) => {
+  const res = await onRequestGet({
+    env: envComParametros(
+      [{ chave: 'fator_calibragem_global', valor: String(invalidFactor) }],
+      { FATOR_CALIBRAGEM_GLOBAL: '0.98' },
+    ),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes.fator_calibragem_global).toBe(0.98);
+  expect(body.parametros_vigentes.origem).not.toHaveProperty('taxa_fator_calibragem_global');
+});
+
+it.each([0, -0.5])('usa o default quando a calibragem do ambiente não é positiva (%s)', async (invalidFactor) => {
+  const res = await onRequestGet({
+    env: envComParametros([], { FATOR_CALIBRAGEM_GLOBAL: String(invalidFactor) }),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes.fator_calibragem_global).toBe(0.99934);
+  expect(body.parametros_vigentes.origem).not.toHaveProperty('taxa_fator_calibragem_global');
+});
+
+it('preserva calibragem D1 positiva com precedência sobre o ambiente', async () => {
+  const res = await onRequestGet({
+    env: envComParametros(
+      [{ chave: 'fator_calibragem_global', valor: '0.97' }],
+      { FATOR_CALIBRAGEM_GLOBAL: '0.98' },
+    ),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes.fator_calibragem_global).toBe(0.97);
+  expect(body.parametros_vigentes.origem.taxa_fator_calibragem_global).toBe('d1');
+  expect(body.parametros_vigentes.origem).not.toHaveProperty('fator_calibragem_global');
+});

--- a/functions/api/_shared/calibragem.mjs
+++ b/functions/api/_shared/calibragem.mjs
@@ -1,0 +1,11 @@
+export const FATOR_CALIBRAGEM_GLOBAL_PADRAO = 0.99934;
+
+export function fatorCalibragemValido(valor) {
+  return Number.isFinite(valor) && valor > 0;
+}
+
+export function resolverFatorCalibragemGlobal(valorD1, valorAmbiente) {
+  if (fatorCalibragemValido(valorD1)) return valorD1;
+  if (fatorCalibragemValido(valorAmbiente)) return valorAmbiente;
+  return FATOR_CALIBRAGEM_GLOBAL_PADRAO;
+}

--- a/functions/api/calcular.js
+++ b/functions/api/calcular.js
@@ -5,6 +5,7 @@ import { parseCotacaoVendaCsv } from './cotacao-csv.mjs';
 import { fetchComTimeout } from './fetch-timeout.mjs';
 import { analisarCompraEmReais } from './compra-reais.mjs';
 import { requireAllowedOrigin, enforceRateLimit, SECURITY_HEADERS } from './_shared/security.js';
+import { fatorCalibragemValido, resolverFatorCalibragemGlobal } from './_shared/calibragem.mjs';
 
 export async function onRequestPost(context) {
     const defaultHeaders = { "Content-Type": "application/json", ...SECURITY_HEADERS };
@@ -90,10 +91,9 @@ export async function onRequestPost(context) {
         const SPREAD_GLOBAL_FECHADO = resolveParam('spread_global_fechado', globalSpreadFechadoInformado, 'TAXA_SPREAD_GLOBAL_FECHADO', 0.0118);
         const calibragemD1 = parametrosD1.fator_calibragem_global;
         const calibragemEnv = readFiniteEnv('FATOR_CALIBRAGEM_GLOBAL');
-        const calibragemD1Valida = Number.isFinite(calibragemD1) && calibragemD1 > 0;
-        const CALIBRAGEM = calibragemD1Valida ? calibragemD1 : (calibragemEnv > 0 ? calibragemEnv : 0.99934);
-        if (calibragemD1Valida) origem.fator_calibragem_global = 'd1';
-        else delete origem.taxa_fator_calibragem_global;
+        const calibragemD1Valida = fatorCalibragemValido(calibragemD1);
+        const CALIBRAGEM = resolverFatorCalibragemGlobal(calibragemD1, calibragemEnv);
+        if (!calibragemD1Valida) delete origem.taxa_fator_calibragem_global;
 
         const resolveMetricParam = (d1Key, payloadVal, envKey, fallback) => {
             if (d1Key in parametrosD1 && Number.isFinite(parametrosD1[d1Key])) return parametrosD1[d1Key];

--- a/functions/api/parametros.js
+++ b/functions/api/parametros.js
@@ -1,4 +1,9 @@
 ﻿import { getOperationalContext } from './contexto-operacional.mjs';
+import {
+    FATOR_CALIBRAGEM_GLOBAL_PADRAO,
+    fatorCalibragemValido,
+    resolverFatorCalibragemGlobal
+} from './_shared/calibragem.mjs';
 
 export async function onRequestGet(context) {
     const { env } = context;
@@ -14,12 +19,13 @@ export async function onRequestGet(context) {
             spread_cartao: 0.055,
             spread_global_aberto: 0.0078,
             spread_global_fechado: 0.0118,
-            fator_calibragem_global: 0.99934,
+            fator_calibragem_global: FATOR_CALIBRAGEM_GLOBAL_PADRAO,
             backtest_mape_boa_percent: 1.0,
             backtest_mape_atencao_percent: 2.0
         };
 
         const origem = {};
+        let calibragemD1;
 
         // Tentar carregar parâmetros customizados do D1
         try {
@@ -27,6 +33,10 @@ export async function onRequestGet(context) {
             if (rows.results && rows.results.length > 0) {
                 for (const row of rows.results) {
                     const val = parseFloat(row.valor);
+                    if (row.chave === 'fator_calibragem_global') {
+                        if (Number.isFinite(val) && calibragemD1 === undefined) calibragemD1 = val;
+                        continue;
+                    }
                     if (Number.isFinite(val)) {
                         parametros[row.chave] = val;
                         origem[`taxa_${row.chave}`] = 'd1';
@@ -36,6 +46,10 @@ export async function onRequestGet(context) {
         } catch (e) {
             // tabela pode não existir, usar defaults
         }
+
+        const calibragemEnv = parseFloat(env.FATOR_CALIBRAGEM_GLOBAL);
+        parametros.fator_calibragem_global = resolverFatorCalibragemGlobal(calibragemD1, calibragemEnv);
+        if (fatorCalibragemValido(calibragemD1)) origem.taxa_fator_calibragem_global = 'd1';
 
         const spread_global_aplicado = is_plantao
             ? parametros.spread_global_fechado


### PR DESCRIPTION
## Problema

O readback pós-merge do PR #203 encontrou uma segunda inconsistência válida: `/api/calcular` rejeitava `fator_calibragem_global` D1 zero/negativo, mas `GET /api/parametros` ainda publicava o valor inválido e a origem D1.

## Inventário

O fator só é carregado e serializado por `functions/api/calcular.js` e `functions/api/parametros.js`. O endpoint de cálculo também o aplica às duas fontes externas. O cliente `fetchParametros` não tem consumidor; tipos, painel, payload de IA, e-mail, WhatsApp e exports não leem nem serializam esse fator.

## Mudança

- centraliza o contrato estritamente positivo e a precedência D1 > ambiente > default;
- usa o mesmo resolvedor nos dois endpoints;
- conserva a origem D1 somente quando o fator persistido é positivo;
- cobre D1 e ambiente zero/negativo nos dois caminhos;
- preserva os demais parâmetros e a precedência do D1 positivo.

## Evidência

- RED focado: 18/20; falhas exatas para D1 `0` e `-0.5` em `/api/parametros`;
- GREEN focado: 20/20;
- suíte completa no freeze: 93/93 em 14 arquivos;
- `npm run biome`: passou, com aviso informativo preexistente;
- `npm run build`: passou;
- `npm run format:public:check`: passou;
- `git diff --check`: passou;
- todos os checks remotos passaram no head exato;
- solicitação explícita `@codex review`: terminal limpa no commit revisado `a20bc497c1`, sem thread inline;
- commit `a20bc497c10ca168a8b0adcd982c19f9dfa348c3` assinado.

Follow-up de #203 e da [thread Codex](https://github.com/LCV-Ideas-Software/calculadora-app/pull/203#discussion_r3819934293).

Refs #182