### PR TITLE
fix: filtra origens no modo DCC

### DIFF
--- a/functions/api/__tests__/calcular.test.mjs
+++ b/functions/api/__tests__/calcular.test.mjs
@@ -356,3 +356,36 @@ it('modo cobrado em reais retorna cenários sem tocar em cotação', async () =>
   expect(body.compra_em_reais.cenarios.dcc_pura.total_brl).toBe(103.5);
   expect(body.compra_em_reais.diagnostico.cenario_provavel).toBe('dcc_pura');
 });
+
+it.each([
+  {
+    origem: 'D1',
+    bindings: { FATOR_CALIBRAGEM_GLOBAL: '0.98' },
+    parametros: [
+      { chave: 'iof_cartao', valor: '0.04' },
+      { chave: 'spread_cartao', valor: '0.05' },
+      { chave: 'fator_calibragem_global', valor: '0.97' },
+      { chave: 'backtest_mape_boa_percent', valor: '1.5' },
+    ],
+    origemEsperada: { taxa_iof_cartao: 'd1', taxa_spread_cartao: 'd1' },
+  },
+  {
+    origem: 'ambiente',
+    bindings: { FATOR_CALIBRAGEM_GLOBAL: '0.98' },
+    parametros: [],
+    origemEsperada: {},
+  },
+])('modo cobrado em reais omite valor e origem da calibragem vinda de $origem', async ({ bindings, parametros, origemEsperada }) => {
+  vi.stubGlobal('fetch', () => {
+    throw new Error('não deveria chamar rede no modo reais');
+  });
+  const res = await onRequestPost({
+    request: req({ valor_original: 100, cobrado_em_reais: true }),
+    env: envComPtax(5, bindings, parametros),
+  });
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.parametros_vigentes).not.toHaveProperty('fator_calibragem_global');
+  expect(body.parametros_vigentes.origem).toEqual(origemEsperada);
+});

--- a/functions/api/calcular.js
+++ b/functions/api/calcular.js
@@ -121,6 +121,9 @@ export async function onRequestPost(context) {
                 spreadCartao: SPREAD_CARTAO,
                 valorFaturaBrl: valor_fatura_brl,
             });
+            const origemDcc = {};
+            if (origem.taxa_iof_cartao) origemDcc.taxa_iof_cartao = origem.taxa_iof_cartao;
+            if (origem.taxa_spread_cartao) origemDcc.taxa_spread_cartao = origem.taxa_spread_cartao;
             return new Response(JSON.stringify({
                 moeda: 'BRL',
                 valor_original,
@@ -130,7 +133,7 @@ export async function onRequestPost(context) {
                 parametros_vigentes: {
                     iof_cartao: IOF_CARTAO,
                     spread_cartao: SPREAD_CARTAO,
-                    origem,
+                    origem: origemDcc,
                 },
             }), { headers: defaultHeaders });
         }


### PR DESCRIPTION
## Problema

Uma revisão independente pós-merge do PR #204 encontrou proveniência fantasma no modo DCC: esse ramo não aplica nem serializa calibragem/backtest, mas reutilizava o objeto global de origens e podia anunciar essas fontes como se tivessem participado da operação.

## Mudança

- cria a origem específica do retorno DCC;
- conserva apenas `taxa_iof_cartao` e `taxa_spread_cartao`, os dois parâmetros efetivamente aplicados e serializados nesse ramo;
- cobre fator vindo do D1 e do ambiente;
- garante ausência do valor e da origem da calibragem no DCC.

## Evidência

- RED focado: 16/17; o DCC D1 devolveu três origens fantasma de calibragem/backtest;
- GREEN focado: 17/17;
- suíte completa única no freeze: 95/95 em 14 arquivos;
- `npm run biome`: passou, com aviso informativo preexistente;
- `npm run build`: passou;
- `npm run format:public:check`: passou;
- `git diff --check`: passou;
- todos os checks remotos passaram no head exato;
- solicitação explícita `@codex review`: terminal limpa no commit revisado `697faadbd3`, sem thread inline;
- revisão independente read-only: PASS no mesmo head, sem finding;
- commit `697faadbd39069fe8e98ed0f86238ea785f50fe8` assinado.

Follow-up de #204.

Refs #182