### PR TITLE
fix(d1): reject ambiguous contract evidence

### DIFF
--- a/functions/api/__tests__/d1-contract.test.mjs
+++ b/functions/api/__tests__/d1-contract.test.mjs
@@ -120,6 +120,17 @@ describe('contrato sanitizado do D1 compartilhado', () => {
   });
 
   it('rejeita índice UNIQUE inesperado em tabela pertencente ao contrato', () => {
+    const sharedSnapshot = validSnapshot();
+    sharedSnapshot.indexes.push({
+      index_name: 'shared_extra_unique_index',
+      table_name: 'shared_extra_table',
+      column_name: 'id',
+      column_position: 0,
+      is_unique: 1,
+      is_partial: 0,
+    });
+    expect(verifyD1Contract(sharedSnapshot)).toEqual({ ok: true, errors: [] });
+
     const snapshot = validSnapshot();
     snapshot.indexes.push(
       {
@@ -138,14 +149,6 @@ describe('contrato sanitizado do D1 compartilhado', () => {
         is_unique: 1,
         is_partial: 0,
       },
-      {
-        index_name: 'shared_extra_unique_index',
-        table_name: 'shared_extra_table',
-        column_name: 'id',
-        column_position: 0,
-        is_unique: 1,
-        is_partial: 0,
-      },
     );
 
     const result = verifyD1Contract(snapshot);
@@ -153,7 +156,6 @@ describe('contrato sanitizado do D1 compartilhado', () => {
     expect(result.errors).toContain(
       'unexpected unique index on contract-owned table: idx_extra_unique_hits_route_ip',
     );
-    expect(result.errors).not.toContain('unexpected unique index on contract-owned table: shared_extra_unique_index');
   });
 
   it('rejeita evidência de retenção duplicada sem sobrescrever a primeira leitura', () => {

--- a/functions/api/__tests__/d1-contract.test.mjs
+++ b/functions/api/__tests__/d1-contract.test.mjs
@@ -27,6 +27,7 @@ function validSnapshot() {
       column_position: position,
       is_unique: 0,
       is_partial: 0,
+      index_origin: 'c',
     })),
   );
   indexes.push({
@@ -36,6 +37,7 @@ function validSnapshot() {
     column_position: 0,
     is_unique: 0,
     is_partial: 0,
+    index_origin: 'c',
   });
 
   const retention = Object.entries(D1_CONTRACT.retention).map(([table, maxAgeDays]) => ({
@@ -128,6 +130,7 @@ describe('contrato sanitizado do D1 compartilhado', () => {
       column_position: 0,
       is_unique: 1,
       is_partial: 0,
+      index_origin: 'c',
     });
     expect(verifyD1Contract(sharedSnapshot)).toEqual({ ok: true, errors: [] });
 
@@ -140,6 +143,7 @@ describe('contrato sanitizado do D1 compartilhado', () => {
         column_position: 0,
         is_unique: 1,
         is_partial: 0,
+        index_origin: 'c',
       },
       {
         index_name: 'idx_extra_unique_hits_route_ip',
@@ -148,6 +152,7 @@ describe('contrato sanitizado do D1 compartilhado', () => {
         column_position: 1,
         is_unique: 1,
         is_partial: 0,
+        index_origin: 'c',
       },
     );
 
@@ -156,6 +161,49 @@ describe('contrato sanitizado do D1 compartilhado', () => {
     expect(result.errors).toContain(
       'unexpected unique index on contract-owned table: idx_extra_unique_hits_route_ip',
     );
+  });
+
+  it('aceita autoíndice de PK quando origem, colunas e posições coincidem com o contrato', () => {
+    const snapshot = validSnapshot();
+    snapshot.indexes.push(
+      {
+        index_name: 'sqlite_autoindex_calc_ptax_cache_1',
+        table_name: 'calc_ptax_cache',
+        column_name: 'data_cotacao',
+        column_position: 0,
+        is_unique: 1,
+        is_partial: 0,
+        index_origin: 'pk',
+      },
+      {
+        index_name: 'sqlite_autoindex_calc_ptax_cache_1',
+        table_name: 'calc_ptax_cache',
+        column_name: 'moeda',
+        column_position: 1,
+        is_unique: 1,
+        is_partial: 0,
+        index_origin: 'pk',
+      },
+    );
+
+    expect(verifyD1Contract(snapshot)).toEqual({ ok: true, errors: [] });
+  });
+
+  it('rejeita índice UNIQUE de expressão mesmo quando a coluna não tem nome', () => {
+    const snapshot = validSnapshot();
+    snapshot.indexes.push({
+      index_name: 'idx_extra_unique_expression',
+      table_name: 'calc_rate_limit_hits',
+      column_name: null,
+      column_position: 0,
+      is_unique: 1,
+      is_partial: 0,
+      index_origin: 'c',
+    });
+
+    const result = verifyD1Contract(snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('unexpected unique index on contract-owned table: idx_extra_unique_expression');
   });
 
   it('rejeita evidência de retenção duplicada sem sobrescrever a primeira leitura', () => {

--- a/functions/api/__tests__/d1-contract.test.mjs
+++ b/functions/api/__tests__/d1-contract.test.mjs
@@ -119,6 +119,58 @@ describe('contrato sanitizado do D1 compartilhado', () => {
     expect(result.errors).toContain('index must be non-partial: idx_calc_rate_limit_hits_lookup');
   });
 
+  it('rejeita índice UNIQUE inesperado em tabela pertencente ao contrato', () => {
+    const snapshot = validSnapshot();
+    snapshot.indexes.push(
+      {
+        index_name: 'idx_extra_unique_hits_route_ip',
+        table_name: 'calc_rate_limit_hits',
+        column_name: 'route_key',
+        column_position: 0,
+        is_unique: 1,
+        is_partial: 0,
+      },
+      {
+        index_name: 'idx_extra_unique_hits_route_ip',
+        table_name: 'calc_rate_limit_hits',
+        column_name: 'ip',
+        column_position: 1,
+        is_unique: 1,
+        is_partial: 0,
+      },
+      {
+        index_name: 'shared_extra_unique_index',
+        table_name: 'shared_extra_table',
+        column_name: 'id',
+        column_position: 0,
+        is_unique: 1,
+        is_partial: 0,
+      },
+    );
+
+    const result = verifyD1Contract(snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'unexpected unique index on contract-owned table: idx_extra_unique_hits_route_ip',
+    );
+    expect(result.errors).not.toContain('unexpected unique index on contract-owned table: shared_extra_unique_index');
+  });
+
+  it('rejeita evidência de retenção duplicada sem sobrescrever a primeira leitura', () => {
+    const snapshot = validSnapshot();
+    const aiUsageRetention = snapshot.retention.find((row) => row.table_name === 'ai_usage_logs');
+    snapshot.retention = [
+      ...snapshot.retention.filter((row) => row.table_name !== 'ai_usage_logs'),
+      { ...aiUsageRetention, stale_rows: 5 },
+      { ...aiUsageRetention, stale_rows: 0 },
+    ];
+
+    const result = verifyD1Contract(snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('duplicate retention evidence: ai_usage_logs');
+    expect(result.errors).toContain('retention violation: ai_usage_logs has 5 stale row(s)');
+  });
+
   it('exige a PK de políticas e posições PK canônicas sem lacunas', () => {
     const snapshot = validSnapshot();
     snapshot.schema = snapshot.schema.map((row) => {

--- a/scripts/verify-d1-contract.mjs
+++ b/scripts/verify-d1-contract.mjs
@@ -199,9 +199,26 @@ export function verifyD1Contract(snapshot) {
     }
   }
 
-  const retentionByTable = new Map(
-    retentionRows.filter((row) => typeof row?.table_name === 'string').map((row) => [row.table_name, row]),
-  );
+  const contractTables = new Set(Object.keys(D1_CONTRACT.tables));
+  const canonicalIndexes = new Set(Object.keys(D1_CONTRACT.indexes));
+  for (const [name, index] of indexesByName) {
+    if (canonicalIndexes.has(name) || ![...index.tables].some((table) => contractTables.has(table))) continue;
+    if (index.uniqueFlags.size !== 1 || !index.uniqueFlags.has(0)) {
+      errors.push(`unexpected unique index on contract-owned table: ${name}`);
+    }
+  }
+
+  const retentionByTable = new Map();
+  const duplicateRetentionTables = new Set();
+  for (const row of retentionRows) {
+    if (typeof row?.table_name !== 'string') continue;
+    if (retentionByTable.has(row.table_name)) {
+      if (Object.hasOwn(D1_CONTRACT.retention, row.table_name)) duplicateRetentionTables.add(row.table_name);
+      continue;
+    }
+    retentionByTable.set(row.table_name, row);
+  }
+  for (const table of duplicateRetentionTables) errors.push(`duplicate retention evidence: ${table}`);
   for (const [table, maxAgeDays] of Object.entries(D1_CONTRACT.retention)) {
     const actual = retentionByTable.get(table);
     if (!actual) {

--- a/scripts/verify-d1-contract.mjs
+++ b/scripts/verify-d1-contract.mjs
@@ -135,19 +135,39 @@ export function verifyD1Contract(snapshot) {
   }
 
   const indexesByName = new Map();
+  const indexMetadataByName = new Map();
   const invalidIndexPositions = new Set();
   for (const row of indexRows) {
-    if (
-      typeof row?.index_name !== 'string' ||
-      typeof row?.table_name !== 'string' ||
-      typeof row?.column_name !== 'string'
-    ) {
+    if (typeof row?.index_name !== 'string' || typeof row?.table_name !== 'string') continue;
+    const metadata = indexMetadataByName.get(row.index_name) ?? {
+      tables: new Set(),
+      columns: [],
+      uniqueFlags: new Set(),
+      partialFlags: new Set(),
+      origins: new Set(),
+      hasMalformedColumns: false,
+      hasInvalidPositions: false,
+    };
+    metadata.tables.add(row.table_name);
+    metadata.uniqueFlags.add(row.is_unique);
+    metadata.partialFlags.add(row.is_partial);
+    metadata.origins.add(row.index_origin);
+    if (typeof row.column_name !== 'string') {
+      metadata.hasMalformedColumns = true;
+      indexMetadataByName.set(row.index_name, metadata);
       continue;
     }
     if (!Number.isInteger(row.column_position)) {
+      metadata.hasInvalidPositions = true;
+      indexMetadataByName.set(row.index_name, metadata);
       invalidIndexPositions.add(row.index_name);
       continue;
     }
+    metadata.columns.push({
+      column: row.column_name,
+      position: row.column_position,
+    });
+    indexMetadataByName.set(row.index_name, metadata);
     const index = indexesByName.get(row.index_name) ?? {
       tables: new Set(),
       columns: [],
@@ -201,9 +221,26 @@ export function verifyD1Contract(snapshot) {
 
   const contractTables = new Set(Object.keys(D1_CONTRACT.tables));
   const canonicalIndexes = new Set(Object.keys(D1_CONTRACT.indexes));
-  for (const [name, index] of indexesByName) {
+  const isCanonicalPrimaryKeyAutoindex = (name, index) => {
+    const tables = [...index.tables];
+    if (tables.length !== 1) return false;
+    const [table] = tables;
+    const expectedColumns = D1_CONTRACT.primaryKeys[table];
+    if (!expectedColumns || !name.startsWith(`sqlite_autoindex_${table}_`)) return false;
+    if (index.hasMalformedColumns || index.hasInvalidPositions) return false;
+    if (index.origins.size !== 1 || !index.origins.has('pk')) return false;
+    if (index.uniqueFlags.size !== 1 || !index.uniqueFlags.has(1)) return false;
+    if (index.partialFlags.size !== 1 || !index.partialFlags.has(0)) return false;
+    const orderedColumns = [...index.columns].sort((left, right) => left.position - right.position);
+    const actualColumns = orderedColumns.map(({ column }) => column);
+    const actualPositions = orderedColumns.map(({ position }) => position);
+    const expectedPositions = expectedColumns.map((_, position) => position);
+    return sameOrderedValues(actualColumns, expectedColumns) && sameOrderedValues(actualPositions, expectedPositions);
+  };
+  for (const [name, index] of indexMetadataByName) {
     if (canonicalIndexes.has(name) || ![...index.tables].some((table) => contractTables.has(table))) continue;
-    if (index.uniqueFlags.size !== 1 || !index.uniqueFlags.has(0)) {
+    const isProvenNonUnique = index.uniqueFlags.size === 1 && index.uniqueFlags.has(0);
+    if (!isProvenNonUnique && !isCanonicalPrimaryKeyAutoindex(name, index)) {
       errors.push(`unexpected unique index on contract-owned table: ${name}`);
     }
   }


### PR DESCRIPTION
## Resumo

- rejeita índices `UNIQUE` não canônicos em tabelas pertencentes ao contrato D1;
- preserva índices extras em tabelas compartilhadas;
- mantém metadados de índices de expressão mesmo quando `column_name` é nulo;
- aceita autoíndices de chave primária somente quando nome, tabela, origem, flags, colunas e posições provam exatamente a PK declarada;
- rejeita evidência de retenção duplicada sem permitir sobrescrita da primeira observação.

## Causa raiz

O verificador percorria apenas os dois nomes de índice canônicos, então um terceiro índice `UNIQUE` em uma tabela da aplicação não participava da decisão. A retenção era convertida diretamente em `Map`, cuja semântica _last-write-wins_ apagava silenciosamente a primeira leitura quando a tabela aparecia duas vezes. A primeira correção também descartava linhas de índice com coluna nula e tratava autoíndices legítimos de PK como índices `UNIQUE` inesperados.

## Evidência RED → GREEN

- RED assinado `27dcc78`: 9 casos, exatamente os 2 achados originais falharam e 7 passaram;
- RED assinado `d307762`: 11 casos, exatamente os 2 edge cases da revisão Codex falharam e 9 passaram;
- head assinado `ad22a81`: teste focado 11/11;
- suíte completa: 14 arquivos e 99/99 testes;
- `npm run biome`;
- `npm run build`;
- `npm run format:public:check`;
- Ultrabrain strict `calcula-7-pr206-final-strict-v2`: `valid`, zero gaps;
- cross-review v2 `1d640b22-2bcc-4c99-a253-b6cfd874f5a5`: Claude e Grok `READY`, sem blockers; Gemini indisponível por spend cap e Perplexity não concluiu antes do encerramento da rodada;
- uma revisão GitHub Codex no head exato `8cbb997`; os dois achados estão cobertos pelo RED `d307762` e pelo head atual.

## Escopo e segurança

O patch altera somente o verificador sanitizado e seus testes. Não consulta nem modifica dados D1, não muda o contrato canônico, não toca no runtime da aplicação e não amplia o tratamento para objetos de tabelas compartilhadas. O PR permanece draft para revisão humana do head exato.

Closes #184
Refs #202