### PR TITLE
fix(ci): run zizmor for merge groups

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
+  merge_group:
+    types:
+      - checks_requested
 
 permissions: {}
 


### PR DESCRIPTION
## Resumo

- restaura o evento `merge_group.checks_requested` no workflow Zizmor;
- preserva o check obrigatório `zizmor`, as permissões, os pins e o ruleset;
- corrige o check ausente nos SHAs sintéticos da merge queue do PR #208.

## Evidência

Os três ciclos de fila de #208 executaram os outros cinco checks obrigatórios, mas não criaram `zizmor`; dois terminaram em `checks_timed_out`. O histórico mostra que o trigger foi removido em 14/08/2026 pelo PR #193 durante a adoção da action oficial.

## Validação

- 99/99 testes;
- Biome, build e formato público verdes;
- actionlint, Actions lock e git diff --check verdes;
- revisão independente: Claude, DeepSeek e Grok READY, sem objeção técnica.

O PR não habilita auto-merge e deve atravessar admissão humana e `merge_group`, onde o check `zizmor` será a prova funcional do reparo.

Rastreamento: [GIT-86](https://linear.app/lcv-ideas-software/issue/GIT-86/governanca-fechar-checks-e-allowlist-da-merge-queue-antes-do) e [github-operations#82](https://github.com/LCV-Ideas-Software/github-operations/issues/82).