### PR TITLE
fix(compliance): verify third-party inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: 24
           check-latest: true
       - run: npm ci --no-audit --no-fund
+      - run: npm run verify:thirdparty
       - run: npm run biome
       - run: npm run build
       - run: npm test

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -1,13 +1,22 @@
 # Third-Party Components
 
-| Componente | Versão | Licença Original | Modificado? | Link de Origem |
-|------------|--------|------------------|-------------|----------------|
-| @tailwindcss/vite | ^4.2.2 | MIT | Não | https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz |
-| @types/react | ^19.2.14 | MIT | Não | https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz |
-| @types/react-dom | ^19.2.3 | MIT | Não | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz |
-| @vitejs/plugin-react | ^6.0.1 | MIT | Não | https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz |
-| react | ^19.2.4 | MIT | Não | https://registry.npmjs.org/react/-/react-19.2.4.tgz |
-| react-dom | ^19.2.4 | MIT | Não | https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz |
-| tailwindcss | ^4.2.2 | MIT | Não | https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz |
-| typescript | ~6.0.2 | Apache-2.0 | Não | https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz |
-| vite | ^8.0.3 | MIT | Não | https://registry.npmjs.org/vite/-/vite-8.0.3.tgz |
+Este inventário cobre todas as dependências diretas declaradas em `package.json`.
+As versões exatas e as dependências transitivas permanecem registradas no
+[`package-lock.json`](https://github.com/LCV-Ideas-Software/calculadora-app/blob/main/package-lock.json).
+
+| Componente | Escopo | Licença declarada no lockfile | Modificado? | Origem |
+|------------|--------|--------------------------------|-------------|--------|
+| `@biomejs/biome` | desenvolvimento | MIT OR Apache-2.0 | Não | https://www.npmjs.com/package/@biomejs/biome |
+| `@tailwindcss/vite` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@tailwindcss/vite |
+| `@types/react` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@types/react |
+| `@types/react-dom` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@types/react-dom |
+| `@vitejs/plugin-react` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@vitejs/plugin-react |
+| `dompurify` | runtime | (MPL-2.0 OR Apache-2.0) | Não | https://www.npmjs.com/package/dompurify |
+| `prettier` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/prettier |
+| `react` | runtime | MIT | Não | https://www.npmjs.com/package/react |
+| `react-dom` | runtime | MIT | Não | https://www.npmjs.com/package/react-dom |
+| `sanitize-html` | runtime | MIT | Não | https://www.npmjs.com/package/sanitize-html |
+| `tailwindcss` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/tailwindcss |
+| `typescript` | desenvolvimento | Apache-2.0 | Não | https://www.npmjs.com/package/typescript |
+| `vite` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/vite |
+| `vitest` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/vitest |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "verify:d1-contract": "node scripts/verify-d1-contract.mjs",
+    "verify:thirdparty": "node scripts/verify-thirdparty.mjs",
     "format": "biome format --write src",
     "lint": "biome check src",
     "biome": "biome check .",

--- a/public/legal/THIRDPARTY.md
+++ b/public/legal/THIRDPARTY.md
@@ -1,13 +1,22 @@
 # Third-Party Components
 
-| Componente | Versão | Licença Original | Modificado? | Link de Origem |
-|------------|--------|------------------|-------------|----------------|
-| @tailwindcss/vite | ^4.2.2 | MIT | Não | https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz |
-| @types/react | ^19.2.14 | MIT | Não | https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz |
-| @types/react-dom | ^19.2.3 | MIT | Não | https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz |
-| @vitejs/plugin-react | ^6.0.1 | MIT | Não | https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz |
-| react | ^19.2.4 | MIT | Não | https://registry.npmjs.org/react/-/react-19.2.4.tgz |
-| react-dom | ^19.2.4 | MIT | Não | https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz |
-| tailwindcss | ^4.2.2 | MIT | Não | https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz |
-| typescript | ~6.0.2 | Apache-2.0 | Não | https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz |
-| vite | ^8.0.3 | MIT | Não | https://registry.npmjs.org/vite/-/vite-8.0.3.tgz |
+Este inventário cobre todas as dependências diretas declaradas em `package.json`.
+As versões exatas e as dependências transitivas permanecem registradas no
+[`package-lock.json`](https://github.com/LCV-Ideas-Software/calculadora-app/blob/main/package-lock.json).
+
+| Componente | Escopo | Licença declarada no lockfile | Modificado? | Origem |
+|------------|--------|--------------------------------|-------------|--------|
+| `@biomejs/biome` | desenvolvimento | MIT OR Apache-2.0 | Não | https://www.npmjs.com/package/@biomejs/biome |
+| `@tailwindcss/vite` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@tailwindcss/vite |
+| `@types/react` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@types/react |
+| `@types/react-dom` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@types/react-dom |
+| `@vitejs/plugin-react` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/@vitejs/plugin-react |
+| `dompurify` | runtime | (MPL-2.0 OR Apache-2.0) | Não | https://www.npmjs.com/package/dompurify |
+| `prettier` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/prettier |
+| `react` | runtime | MIT | Não | https://www.npmjs.com/package/react |
+| `react-dom` | runtime | MIT | Não | https://www.npmjs.com/package/react-dom |
+| `sanitize-html` | runtime | MIT | Não | https://www.npmjs.com/package/sanitize-html |
+| `tailwindcss` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/tailwindcss |
+| `typescript` | desenvolvimento | Apache-2.0 | Não | https://www.npmjs.com/package/typescript |
+| `vite` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/vite |
+| `vitest` | desenvolvimento | MIT | Não | https://www.npmjs.com/package/vitest |

--- a/scripts/verify-thirdparty.mjs
+++ b/scripts/verify-thirdparty.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT_INVENTORY = "THIRDPARTY.md";
+const PUBLIC_INVENTORY = "public/legal/THIRDPARTY.md";
+const TABLE_HEADER = [
+  "Componente",
+  "Escopo",
+  "Licença declarada no lockfile",
+  "Modificado?",
+  "Origem",
+];
+
+function normalizeCell(value) {
+  return value.trim().replace(/^`|`$/gu, "");
+}
+
+function parseTable(markdown) {
+  const lines = markdown.split(/\r?\n/u);
+  const headerIndex = lines.findIndex((line) =>
+    line.includes("| Componente | Escopo | Licença declarada no lockfile |"),
+  );
+  assert.notEqual(headerIndex, -1, "THIRDPARTY table header is missing");
+
+  const header = lines[headerIndex]
+    .split("|")
+    .slice(1, -1)
+    .map(normalizeCell);
+  assert.deepEqual(header, TABLE_HEADER, "THIRDPARTY table header changed");
+
+  const records = [];
+  for (const line of lines.slice(headerIndex + 2)) {
+    if (!line.startsWith("|")) break;
+    const cells = line.split("|").slice(1, -1).map(normalizeCell);
+    assert.equal(cells.length, TABLE_HEADER.length, `invalid THIRDPARTY row: ${line}`);
+    records.push({
+      name: cells[0],
+      scope: cells[1],
+      license: cells[2],
+      modified: cells[3],
+      origin: cells[4],
+    });
+  }
+  return records;
+}
+
+function expectedInventory(packageJson, packageLock) {
+  const scopes = [
+    ["dependencies", "runtime"],
+    ["devDependencies", "desenvolvimento"],
+  ];
+  const expected = [];
+
+  for (const [manifestKey, scope] of scopes) {
+    for (const name of Object.keys(packageJson[manifestKey] ?? {})) {
+      const lockEntry = packageLock.packages?.[`node_modules/${name}`];
+      assert.ok(lockEntry, `${name} is missing from package-lock.json`);
+      assert.equal(typeof lockEntry.license, "string", `${name} lacks lockfile license metadata`);
+      assert.ok(lockEntry.license.trim(), `${name} has an empty lockfile license`);
+      expected.push({
+        name,
+        scope,
+        license: lockEntry.license,
+        modified: "Não",
+        origin: `https://www.npmjs.com/package/${name}`,
+      });
+    }
+  }
+
+  return expected.sort((left, right) => left.name.localeCompare(right.name, "en"));
+}
+
+export function verifyThirdPartyInventory({
+  packageJson,
+  packageLock,
+  rootInventory,
+  publicInventory,
+}) {
+  assert.equal(
+    publicInventory,
+    rootInventory,
+    `${ROOT_INVENTORY} and ${PUBLIC_INVENTORY} must be byte-identical`,
+  );
+
+  const actual = parseTable(rootInventory);
+  const names = actual.map(({ name }) => name);
+  assert.equal(new Set(names).size, names.length, "THIRDPARTY contains duplicate components");
+
+  const expected = expectedInventory(packageJson, packageLock);
+  assert.deepEqual(actual, expected, "THIRDPARTY does not match direct dependency metadata");
+}
+
+async function main() {
+  const root = process.cwd();
+  const [packageJson, packageLock, rootInventory, publicInventory] = await Promise.all([
+    readFile(resolve(root, "package.json"), "utf8").then(JSON.parse),
+    readFile(resolve(root, "package-lock.json"), "utf8").then(JSON.parse),
+    readFile(resolve(root, ROOT_INVENTORY), "utf8"),
+    readFile(resolve(root, PUBLIC_INVENTORY), "utf8"),
+  ]);
+
+  verifyThirdPartyInventory({ packageJson, packageLock, rootInventory, publicInventory });
+  console.log("THIRDPARTY inventory matches all direct dependencies.");
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPoint === import.meta.url) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-thirdparty.test.mjs
+++ b/scripts/verify-thirdparty.test.mjs
@@ -1,0 +1,76 @@
+import { expect, test } from "vitest";
+
+import { verifyThirdPartyInventory } from "./verify-thirdparty.mjs";
+
+const packageJson = {
+  dependencies: { alpha: "^1.0.0" },
+  devDependencies: { beta: "^2.0.0" },
+};
+
+const packageLock = {
+  packages: {
+    "node_modules/alpha": { version: "1.0.0", license: "MIT" },
+    "node_modules/beta": { version: "2.0.0", license: "Apache-2.0" },
+  },
+};
+
+function inventory(rows = [
+  "| `alpha` | runtime | MIT | Não | https://www.npmjs.com/package/alpha |",
+  "| `beta` | desenvolvimento | Apache-2.0 | Não | https://www.npmjs.com/package/beta |",
+]) {
+  return `# Third-Party Components
+
+| Componente | Escopo | Licença declarada no lockfile | Modificado? | Origem |
+|------------|--------|--------------------------------|-------------|--------|
+${rows.join("\n")}
+`;
+}
+
+function verify(overrides = {}) {
+  const rootInventory = overrides.rootInventory ?? inventory();
+  verifyThirdPartyInventory({
+    packageJson: overrides.packageJson ?? packageJson,
+    packageLock: overrides.packageLock ?? packageLock,
+    rootInventory,
+    publicInventory: overrides.publicInventory ?? rootInventory,
+  });
+}
+
+test("accepts complete byte-identical direct-dependency inventories", () => {
+  expect(() => verify()).not.toThrow();
+});
+
+test("does not couple inventory validity to dependency versions", () => {
+  expect(() =>
+    verify({
+      packageLock: {
+        packages: {
+          ...packageLock.packages,
+          "node_modules/alpha": { version: "1.9.9", license: "MIT" },
+        },
+      },
+    }),
+  ).not.toThrow();
+});
+
+test("rejects a missing direct dependency", () => {
+  expect(() =>
+    verify({ rootInventory: inventory([inventory().split("\n")[4]]) }),
+  ).toThrow(/does not match direct dependency metadata/u);
+});
+
+test("rejects duplicate components", () => {
+  const row = "| `alpha` | runtime | MIT | Não | https://www.npmjs.com/package/alpha |";
+  expect(() => verify({ rootInventory: inventory([row, row]) })).toThrow(/duplicate/u);
+});
+
+test("rejects license drift", () => {
+  const changed = inventory().replace("| `alpha` | runtime | MIT |", "| `alpha` | runtime | ISC |");
+  expect(() => verify({ rootInventory: changed })).toThrow(/does not match/u);
+});
+
+test("rejects divergence between root and public copies", () => {
+  expect(() => verify({ publicInventory: `${inventory()}\n` })).toThrow(
+    /must be byte-identical/u,
+  );
+});


### PR DESCRIPTION
## Resumo

- corrige as duas cópias publicadas do inventário THIRDPARTY para cobrir todas as 14 dependências diretas;
- troca versões incorporadas por metadados estáveis de escopo, licença e origem, mantendo versões exatas/transitivas no `package-lock.json`;
- adiciona verificação fail-closed de identidade entre as cópias, cobertura, duplicação, escopo, licença e origem;
- executa a verificação dentro de `Test application`, check já obrigatório no head e no `merge_group`.

## Compatibilidade com o Dependabot

Um bump que preserve nome, escopo e licença continua válido sem edição documental. Dependências novas/removidas ou mudança de licença exigem atualização explícita e falham no CI. O PR #208 permanece canônico e não foi modificado.

## Verificação

- `npm test -- scripts/verify-thirdparty.test.mjs` — 6/6
- `npm run verify:thirdparty` — PASS
- `npm test` — 105/105
- `npm run biome` — PASS
- `npm run build` — PASS
- `npm run format:public:check` — PASS
- `git diff --check` — PASS

Closes #210

Linear: [CALCULA-13](https://linear.app/lcv-ideas-software/issue/CALCULA-13/maintenance-tornar-o-inventario-thirdparty-verificavel-e-resistente-a)

