### PR TITLE
ci: use official Linear Release action

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -21,6 +21,7 @@ workflows:
         - 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020'
     '.github/workflows/linear-release.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+        - 'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205'
     '.github/workflows/pages.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d'
@@ -92,6 +93,11 @@ dependencies:
         commit: 'sha1-db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28'
         owner_id: 9919
         repo_id: 259445878
+    'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':
+        ref: 'v0.16.0'
+        commit: 'sha1-0a25abab892a91062ebf42260dbb2ce6277aa205'
+        owner_id: 46686594
+        repo_id: 1150447766
     'ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc':
         ref: 'v2.4.4'
         commit: 'sha1-2d1146689b8cda280b9bc96326124645441f03bc'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -53,28 +53,18 @@ jobs:
           fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Download verificado por digest — sem wrapper de terceiro: o binário oficial
-      # do CLI só executa se o SHA-256 conferir com o valor gravado abaixo
-      # (recomputado localmente e conferido contra o digest declarado pela API do
-      # GitHub em 17/08/2026). Troca de versão exige atualizar URL e digest juntos,
-      # por desenho. Inventário e fronteira de confiança em THIRDPARTY.md do
-      # repositório de governança.
+      # Action oficial da Linear, pinada no SHA completo da release assinada
+      # v0.16.0. O risco residual de o install.sh baixar o CLI sem validar digest
+      # está rastreado upstream em linear/linear-release-action#59.
       #
       # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (digest divergente, indisponibilidade, segredo expirado) NUNCA pode
-      # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
-      # falha fica visível na anotação do passo; commits não sincronizados embarcam
-      # na release seguinte.
-      - name: Create Linear release (CLI verificado por digest)
+      # falha NUNCA pode bloquear portões que varrem todos os runs do SHA. O run
+      # conclui verde e a falha fica visível na anotação do passo; commits não
+      # sincronizados embarcam na release seguinte.
+      - name: Create Linear release (action oficial)
         id: linear_release
         continue-on-error: true
-        env:
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          CLI_URL: https://github.com/linear/linear-release/releases/download/v0.15.0/linear-release-linux-x64
-          CLI_SHA256: 06eddce3f0d306fcdfed634105a57b02695b5c4fb40c42eb56d13feced729c99
-        run: |
-          bin="$RUNNER_TEMP/linear-release"
-          curl -fsSL "$CLI_URL" -o "$bin"
-          echo "$CLI_SHA256  $bin" | sha256sum -c -
-          chmod +x "$bin"
-          "$bin" sync
+        uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          cli_version: v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- The production-gated Linear Release workflow now uses the official `linear/linear-release-action` v0.16.0, pinned to its signed full commit SHA, while preserving the exact deployed-SHA checkout, least-privilege permissions, dedicated environment and best-effort behavior.
 - Security, dependency review and Cloudflare deployment workflows now use the official GitHub, OpenSSF, Zizmor and Cloudflare Actions directly, without organization-specific wrappers or policy manifests. The Pages D1 binding remains in Cloudflare's native dashboard configuration, so no operational database identifier is published in source control.
 - This web application retains its internal `APP_VERSION` and changelog but no longer creates GitHub Releases or version tags; those distribution artifacts are reserved for repositories that publish packages.
 - The npm package is marked `private` because this repository deploys a web application rather than publishing a package.


### PR DESCRIPTION
## Resumo

- substitui o instalador customizado do Linear CLI pela action oficial `linear/linear-release-action` v0.16.0;
- fixa a action no commit upstream assinado `0a25abab892a91062ebf42260dbb2ce6277aa205`;
- preserva o gatilho após `Deploy`, checkout do SHA efetivamente implantado, histórico completo, environment dedicado, permissões mínimas, concorrência e comportamento best-effort;
- atualiza `actions.lock` e o changelog;
- não altera CodeQL v4.37.8, Deploy, Scorecard, Dependabot nem outros gates.

## Verificações

- `git diff --check`
- `actionlint`
- `zizmor .`
- `gh actions-lock --verify`
- `npm test` — 15 arquivos, 105 testes
- `npm run biome`
- `npm run build`
- `npm run format:public:check`
- auditorias read-only local, live e de tracking sem bloqueadores no diff
- cross-review-v2: Claude, DeepSeek e Grok retornaram `READY`; Gemini estava indisponível por autenticação do provedor e a chamada Perplexity não concluiu antes do timeout do cliente

## Proveniência e risco residual

- action oficial: https://github.com/linear/linear-release-action
- documentação oficial: https://github.com/linear/linear-release-action#readme
- o risco de instalação do CLI sem verificação de digest permanece rastreado em https://github.com/linear/linear-release-action/issues/59

Após o merge, o canário exige `Deploy` verde e exatamente uma Linear Release `Released` para o mesmo SHA completo.

Closes #214
Fixes CALCULA-15