### PR TITLE
fix(ci): preserve Dependabot cooldown and release queue (CALCULA-16)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     cooldown:
       default-days: 7
       exclude:
-        - "*"
+        - "actions/*"
+        - "github/*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -17,19 +17,12 @@ on:
 # Política enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
 # workflow e grant mínimo declarado no job.
 permissions: {}
-# Agrupamento intencional: o CLI varre todos os commits desde a última release
-# (fetch-depth: 0). Se um run pendente for substituído por um mais novo, os
-# commits dele embarcam na release do run seguinte — nada se perde; releases
-# agrupam deploys em rajada por desenho, e o grupo evita corrida entre duas
-# criações de release simultâneas.
-# O grupo inclui a CONCLUSÃO do Deploy: o filtro do job (if) só age depois do
-# enfileiramento, então um run de Deploy falhado entraria no mesmo grupo e
-# poderia substituir na fila um run de sucesso pendente — deixando o SHA
-# publicado sem release até o próximo deploy. Com a conclusão na chave, runs de
-# falha (que o if pula) nunca deslocam runs de sucesso.
+# Cada Deploy bem-sucedido precisa gerar sua própria release. `queue: max`
+# preserva todos os runs pendentes do grupo, e a conclusão na chave mantém runs
+# falhados (que o job ignora) separados dos runs de sucesso.
 concurrency:
   group: linear-release-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.conclusion }}
-  cancel-in-progress: false
+  queue: max
 jobs:
   linear_release:
     name: Linear Release
@@ -57,13 +50,11 @@ jobs:
       # v0.16.0. O risco residual de o install.sh baixar o CLI sem validar digest
       # está rastreado upstream em linear/linear-release-action#59.
       #
-      # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha NUNCA pode bloquear portões que varrem todos os runs do SHA. O run
-      # conclui verde e a falha fica visível na anotação do passo; commits não
-      # sincronizados embarcam na release seguinte.
+      # A sincronização falha de forma visível: indisponibilidade, segredo
+      # expirado ou erro upstream deixam o workflow vermelho, evitando perder
+      # silenciosamente a release do SHA publicado.
       - name: Create Linear release (action oficial)
         id: linear_release
-        continue-on-error: true
         uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- The production-gated Linear Release workflow now uses the official `linear/linear-release-action` v0.16.0, pinned to its signed full commit SHA, while preserving the exact deployed-SHA checkout, least-privilege permissions, dedicated environment and best-effort behavior.
+- The production-gated Linear Release workflow now uses the official `linear/linear-release-action` v0.16.0, pinned to its signed full commit SHA, while preserving the exact deployed-SHA checkout, least-privilege permissions and dedicated environment. Pending runs use `queue: max`, and action failures now fail the workflow visibly.
 - Security, dependency review and Cloudflare deployment workflows now use the official GitHub, OpenSSF, Zizmor and Cloudflare Actions directly, without organization-specific wrappers or policy manifests. The Pages D1 binding remains in Cloudflare's native dashboard configuration, so no operational database identifier is published in source control.
 - This web application retains its internal `APP_VERSION` and changelog but no longer creates GitHub Releases or version tags; those distribution artifacts are reserved for repositories that publish packages.
 - The npm package is marked `private` because this repository deploys a web application rather than publishing a package.


### PR DESCRIPTION
## Summary
- keep the seven-day Dependabot cooldown for third-party GitHub Actions
- exempt only official actions/* and github/* software
- queue every pending Linear Release run with queue: max
- fail visibly when the official Linear Release action fails
- preserve triggers, concurrency group, action pins, permissions, secrets, and actions.lock

## Validation
- YAML converted with yq and asserted with jq
- gh actions-lock --verify-local: valid
- Zizmor: no findings
- git diff --check: clean
- actions.lock: byte-identical
- commit: GPG signature verified

Closes #219

Linear: https://linear.app/lcv-ideas-software/issue/CALCULA-16
Refs LCV-Ideas-Software/github-operations#143

Official queue documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-queueing-multiple-pending-runs