### PR TITLE
[CALCULA-17] Expose native Scorecard schedule freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Governanca de trabalho sobre GitHub Projects, Issues e Discussions: quadro dedicado do repositorio, formularios de issue para Incident, Maintenance e Spike, atalhos para Discussions no seletor de issues e o ritual de registro G1..G4 documentado para Claude Code e ChatGPT-Codex.
+- Native OpenSSF Scorecard schedule observability through GitHub's event-filtered workflow badge and history, with the README documenting scheduled execution as best-effort and `push` on `main` as the supported exact-change validation path.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Deploy](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/deploy.yml/badge.svg)](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/deploy.yml)
 [![Pages](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/pages.yml/badge.svg)](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/pages.yml)
 [![CodeQL](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/codeql.yml/badge.svg)](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard (weekly)](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/scorecard.yml/badge.svg?event=schedule)](https://github.com/LCV-Ideas-Software/calculadora-app/actions/workflows/scorecard.yml?query=event%3Aschedule)
 [![runtime: Cloudflare Pages](https://img.shields.io/badge/runtime-Cloudflare%20Pages-orange.svg)](https://pages.cloudflare.com/)
 [![framework: React 19 + Vite 8](https://img.shields.io/badge/framework-React%2019%20%2B%20Vite%208-61dafb.svg)](https://react.dev/)
 [![license: AGPL-3.0-or-later](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](./LICENSE)
@@ -15,6 +16,8 @@
 **Calculadora Financeira** — simulador comparativo de câmbio internacional com análise por IA. React 19 + Vite 8 sobre Cloudflare Pages com D1 backing store, integração Gemini para análises contextuais.
 
 **Status.** Stable. Current application version: **v04.03.03**. See [CHANGELOG.md](./CHANGELOG.md) for the full version history.
+
+**OpenSSF Scorecard freshness.** GitHub Actions schedules are best-effort and [can be delayed during periods of high load](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule). The native badge and its schedule-filtered history show the latest weekly result and execution timestamp; supported `push` runs independently validate changes merged into `main`.
 
 The version history at a glance:
 


### PR DESCRIPTION
## Resumo

- preserva o workflow oficial do OpenSSF Scorecard com os eventos suportados push em main e schedule
- adiciona o badge nativo do GitHub Actions filtrado por schedule e o histórico igualmente filtrado
- documenta, com referência à documentação oficial, que o agendamento é best-effort e pode sofrer atraso

## Causa raiz e decisão

O run semanal não foi perdido: o run 33241985321 iniciou 6h26min33s depois do horário cron e concluiu com sucesso. O audit log registrou WEP allowed:true, sem bloqueio. workflow_dispatch permanece ausente porque é experimental para a action e contraria a decisão official-only registrada na Discussion 65.

Nenhum workflow, action pin ou actions.lock foi alterado. Não há scheduler ou monitor customizado.

## Verificação

- npm test — 15 arquivos / 105 testes
- npm run biome
- npm run build
- npm run format:public:check
- Cross Review b0c1f48f-1a0e-49c7-bf03-d032913484d6 — nenhuma objeção bloqueante

## Referências

- GitHub Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
- Run atrasado: https://github.com/LCV-Ideas-Software/calculadora-app/actions/runs/33241985321
- Decisão oficial: https://github.com/LCV-Ideas-Software/github-operations/discussions/65
- Limitação transversal: https://github.com/LCV-Ideas-Software/github-operations/issues/82
- Linear: https://linear.app/lcv-ideas-software/issue/CALCULA-17

Closes #228