### PR TITLE
chore: update official security action pins (LCV-178)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,6 @@ jobs:
           retention-days: 5
 
       - name: Upload Scorecard results to code scanning
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,4 +33,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        uses: zizmorcore/zizmor-action@cc914d7f3750a2d13d75c7f184a1060aa0e9d482 # v0.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — Calculadora Financeira
 
+## [Unreleased]
+
+### Changed
+
+- Update the official CodeQL Action to v4.38.0 and Zizmor Action to v0.6.4,
+  retaining full commit pins and the existing workflow behavior.
+
 ## [v04.03.04] - 08/09/2026
 
 ### Added


### PR DESCRIPTION
Os workflows ainda usavam versões anteriores das Actions oficiais. Atualiza CodeQL para v4.38.0 e zizmor-action para v0.6.4 pelos SHAs completos verificados, preservando a configuração dos workflows.

Validação local: 99 testes em 14 arquivos, Biome, build, Actionlint, Zizmor e git diff --check aprovados; reprodução das duas divergências passou para zero.

Acompanhamento: [LCV-178](https://linear.app/lcv-ideas-software/issue/LCV-178).
