### PR TITLE
Run Dependabot daily at 05h and group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Sao_Paulo"
+      interval: "cron"
+      cronjob: "0 5 * * *"
+      timezone: "Etc/GMT+3"
     cooldown:
       default-days: 7
       exclude:
@@ -20,6 +19,10 @@ updates:
       include: "scope"
     open-pull-requests-limit: 10
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       minor-e-patch:
         applies-to: version-updates
         patterns:
@@ -31,10 +34,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "America/Sao_Paulo"
+      interval: "cron"
+      cronjob: "0 5 * * *"
+      timezone: "Etc/GMT+3"
     cooldown:
       default-days: 7
     rebase-strategy: auto
@@ -45,6 +47,10 @@ updates:
       include: "scope"
     versioning-strategy: increase
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       minor-e-patch:
         applies-to: version-updates
         patterns:

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ GitHub Pages publishes the separate `site/` directory, with a read-only artifact
 build on PRs and deployment only from `main`. CodeQL uses GitHub Default Setup;
 Dependency Review, Zizmor and Scorecard use their official actions.
 
-Dependabot checks weekly on Monday at 06:00 America/Sao_Paulo, groups minor and
-patch version updates, and submits major updates separately. GitHub native
+Dependabot checks every day, including weekends, at 05:00 (UTC-03:00), using the
+native `cron` schedule and `Etc/GMT+3`. It groups minor and patch version updates,
+submits major updates separately, and groups security fixes independently. GitHub native
 auto-merge is enabled for its same-repository PRs; the rollout requires the four
 native checks (`CI`, `Build Pages artifact`, `Dependency Review`, `Run zizmor`)
 before admission. The workflow does not require human or AI review of those PRs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,24 @@ In scope: application code, Workers/Pages functions, GitHub Actions, dependency 
 
 Out of scope: social engineering, physical attacks, denial-of-service testing without prior written authorization, spam, automated noisy scanning, and reports that rely only on outdated browser or dependency versions without a concrete vulnerable path in this repository.
 
+## Dependency updates
+
+Dependabot checks all configured ecosystems every day, including weekends, at
+05:00 (UTC-03:00), using the native `cron` schedule and `Etc/GMT+3`. GitHub may
+start the jobs later when its update queue is busy. Version updates retain the
+seven-day cooldown and existing groups; official `actions/*` and `github/*`
+updates are excluded from that cooldown.
+
+Security updates run independently of this schedule and cooldown. Each configured
+ecosystem and directory has its own security group, separate from version updates.
+A failing update can delay its security group; diagnose the failure before
+adjusting the native group configuration or recreating a pull request. Any
+configured version ignores also constrain security fixes, so review them when
+upstream compatibility changes. Native auto-merge remains subject to every required check.
+
+See the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
+and [security update documentation](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates).
+
 ## Coordinated disclosure
 
 LCV Ideas & Software will triage reports privately, request clarification when needed, and coordinate remediation before public disclosure. Public disclosure should wait until a fix or mitigation is available, unless there is an immediate user-safety reason to do otherwise.


### PR DESCRIPTION
Dependabot currently checks its configured ecosystems weekly at 06:00. Schedule them every day, including weekends, at 05:00 (UTC-03:00) using GitHub's native cron configuration, and group security fixes separately for each ecosystem/directory.

Preserve existing version groups, cooldowns and compatibility restrictions. Document security timing, ignore constraints and the possibility that one failing update delays its security group. Align the current README cadence.

Validation: parsed YAML and all16 cohort configurations checked for intended changes and label existence; git diff --check passed. 99 tests, Biome and production build passed. Independent configuration review and exact-head repository checks are required before merge.

Closes #247. Linear: [CALCULA-21](https://linear.app/lcv-ideas-software/issue/CALCULA-21).

